### PR TITLE
docs: quaid-scanner health report 2026-06-01

### DIFF
--- a/docs/reports/quaid-scan-2026-06-01.md
+++ b/docs/reports/quaid-scan-2026-06-01.md
@@ -1,0 +1,212 @@
+# quaid-scanner Report: /Users/karstenwade/Projects/AINative-Studio/src/builder-ainative-studio
+
+**Score:** 🔴 1.3/10 — CRITICAL risk
+**Maturity:** sandbox | **Depth:** standard | **Duration:** 0.1s
+**Scanned:** 2026-06-01T21:25:11.219Z
+
+## Pillar Scores
+
+| Pillar | Score | Weight | Findings |
+|--------|-------|--------|----------|
+| Security | 0.0 | 25% | 0C 93W 1I |
+| Governance | 0.0 | 20% | 1C 4W 11I |
+| Community | 1.0 | 15% | 0C 3W 9I |
+| AI Readiness | 2.5 | 15% | 0C 5W 0I |
+| Inclusive Language | 2.0 | 15% | 0C 4W 4I |
+| Technical Rigor | 5.0 | 10% | 0C 2W 4I |
+
+## Critical Findings
+
+### license-detection-scanner:missing
+**Pillar:** Governance | **Category:** license
+
+No license detected. Without a license, the project is under exclusive copyright by default.
+
+_(source: local file check)_
+
+**Suggestion:** Add a LICENSE file to the repository root. Visit https://choosealicense.com/ for guidance.
+
+**Reference:** https://choosealicense.com/
+
+## Warnings
+
+- **[TIMEOUT-binary-artifacts]** Scanner "binary-artifacts" timed out after undefinedms *(Increase scannerTimeout in configuration or check network connectivity)*
+- **[TIMEOUT-dep-pinning-docker]** Scanner "dep-pinning-docker" timed out after undefinedms *(Increase scannerTimeout in configuration or check network connectivity)*
+- **[dep-pinning-packages-1]** Loosely pinned dependency "@ai-sdk/openai": "^2.0.0" uses ^ prefix in dependencies *(Consider pinning "@ai-sdk/openai" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-2]** Loosely pinned dependency "@ai-sdk/react": "^2.0.22" uses ^ prefix in dependencies *(Consider pinning "@ai-sdk/react" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-3]** Loosely pinned dependency "@anthropic-ai/sdk": "^0.65.0" uses ^ prefix in dependencies *(Consider pinning "@anthropic-ai/sdk" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-4]** Loosely pinned dependency "@babel/parser": "^7.28.4" uses ^ prefix in dependencies *(Consider pinning "@babel/parser" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-5]** Loosely pinned dependency "@codesandbox/sandpack-react": "^2.20.0" uses ^ prefix in dependencies *(Consider pinning "@codesandbox/sandpack-react" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-6]** Loosely pinned dependency "@codesandbox/sandpack-themes": "^2.0.21" uses ^ prefix in dependencies *(Consider pinning "@codesandbox/sandpack-themes" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-7]** Loosely pinned dependency "@monaco-editor/react": "^4.7.0" uses ^ prefix in dependencies *(Consider pinning "@monaco-editor/react" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-8]** Loosely pinned dependency "@radix-ui/react-accordion": "^1.2.12" uses ^ prefix in dependencies *(Consider pinning "@radix-ui/react-accordion" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-9]** Loosely pinned dependency "@radix-ui/react-avatar": "^1.1.10" uses ^ prefix in dependencies *(Consider pinning "@radix-ui/react-avatar" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-10]** Loosely pinned dependency "@radix-ui/react-checkbox": "^1.3.3" uses ^ prefix in dependencies *(Consider pinning "@radix-ui/react-checkbox" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-11]** Loosely pinned dependency "@radix-ui/react-collapsible": "^1.1.12" uses ^ prefix in dependencies *(Consider pinning "@radix-ui/react-collapsible" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-12]** Loosely pinned dependency "@radix-ui/react-dialog": "^1.1.15" uses ^ prefix in dependencies *(Consider pinning "@radix-ui/react-dialog" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-13]** Loosely pinned dependency "@radix-ui/react-dropdown-menu": "^2.1.16" uses ^ prefix in dependencies *(Consider pinning "@radix-ui/react-dropdown-menu" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-14]** Loosely pinned dependency "@radix-ui/react-hover-card": "^1.1.15" uses ^ prefix in dependencies *(Consider pinning "@radix-ui/react-hover-card" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-15]** Loosely pinned dependency "@radix-ui/react-label": "^2.1.7" uses ^ prefix in dependencies *(Consider pinning "@radix-ui/react-label" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-16]** Loosely pinned dependency "@radix-ui/react-popover": "^1.1.15" uses ^ prefix in dependencies *(Consider pinning "@radix-ui/react-popover" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-17]** Loosely pinned dependency "@radix-ui/react-progress": "^1.1.7" uses ^ prefix in dependencies *(Consider pinning "@radix-ui/react-progress" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-18]** Loosely pinned dependency "@radix-ui/react-radio-group": "^1.3.8" uses ^ prefix in dependencies *(Consider pinning "@radix-ui/react-radio-group" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-19]** Loosely pinned dependency "@radix-ui/react-scroll-area": "^1.2.10" uses ^ prefix in dependencies *(Consider pinning "@radix-ui/react-scroll-area" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-20]** Loosely pinned dependency "@radix-ui/react-select": "^2.2.6" uses ^ prefix in dependencies *(Consider pinning "@radix-ui/react-select" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-21]** Loosely pinned dependency "@radix-ui/react-separator": "^1.1.7" uses ^ prefix in dependencies *(Consider pinning "@radix-ui/react-separator" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-22]** Loosely pinned dependency "@radix-ui/react-slot": "^1.2.3" uses ^ prefix in dependencies *(Consider pinning "@radix-ui/react-slot" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-23]** Loosely pinned dependency "@radix-ui/react-tabs": "^1.1.13" uses ^ prefix in dependencies *(Consider pinning "@radix-ui/react-tabs" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-24]** Loosely pinned dependency "@radix-ui/react-toast": "^1.2.15" uses ^ prefix in dependencies *(Consider pinning "@radix-ui/react-toast" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-25]** Loosely pinned dependency "@radix-ui/react-tooltip": "^1.2.8" uses ^ prefix in dependencies *(Consider pinning "@radix-ui/react-tooltip" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-26]** Loosely pinned dependency "@radix-ui/react-use-controllable-state": "^1.2.2" uses ^ prefix in dependencies *(Consider pinning "@radix-ui/react-use-controllable-state" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-27]** Loosely pinned dependency "@sentry/nextjs": "^9.47.1" uses ^ prefix in dependencies *(Consider pinning "@sentry/nextjs" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-28]** Loosely pinned dependency "@types/adm-zip": "^0.5.7" uses ^ prefix in dependencies *(Consider pinning "@types/adm-zip" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-29]** Loosely pinned dependency "@types/archiver": "^6.0.3" uses ^ prefix in dependencies *(Consider pinning "@types/archiver" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-30]** Loosely pinned dependency "@types/ioredis": "^5.0.0" uses ^ prefix in dependencies *(Consider pinning "@types/ioredis" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-31]** Loosely pinned dependency "@types/ws": "^8.18.1" uses ^ prefix in dependencies *(Consider pinning "@types/ws" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-32]** Loosely pinned dependency "@upstash/ratelimit": "^2.0.6" uses ^ prefix in dependencies *(Consider pinning "@upstash/ratelimit" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-33]** Loosely pinned dependency "@upstash/redis": "^1.35.1" uses ^ prefix in dependencies *(Consider pinning "@upstash/redis" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-34]** Loosely pinned dependency "@vercel/postgres": "^0.10.0" uses ^ prefix in dependencies *(Consider pinning "@vercel/postgres" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-35]** Loosely pinned dependency "@vitest/coverage-v8": "^3.2.4" uses ^ prefix in dependencies *(Consider pinning "@vitest/coverage-v8" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-36]** Loosely pinned dependency "adm-zip": "^0.5.16" uses ^ prefix in dependencies *(Consider pinning "adm-zip" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-37]** Loosely pinned dependency "ai": "^5.0.22" uses ^ prefix in dependencies *(Consider pinning "ai" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-38]** Loosely pinned dependency "archiver": "^7.0.1" uses ^ prefix in dependencies *(Consider pinning "archiver" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-39]** Loosely pinned dependency "bcrypt-ts": "^7.1.0" uses ^ prefix in dependencies *(Consider pinning "bcrypt-ts" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-40]** Loosely pinned dependency "class-variance-authority": "^0.7.0" uses ^ prefix in dependencies *(Consider pinning "class-variance-authority" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-41]** Loosely pinned dependency "clsx": "^2.1.1" uses ^ prefix in dependencies *(Consider pinning "clsx" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-42]** Loosely pinned dependency "dotenv": "^16.4.5" uses ^ prefix in dependencies *(Consider pinning "dotenv" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-43]** Loosely pinned dependency "drizzle-kit": "^0.31.4" uses ^ prefix in dependencies *(Consider pinning "drizzle-kit" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-44]** Loosely pinned dependency "drizzle-orm": "^0.44.5" uses ^ prefix in dependencies *(Consider pinning "drizzle-orm" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-45]** Loosely pinned dependency "embla-carousel-react": "^8.6.0" uses ^ prefix in dependencies *(Consider pinning "embla-carousel-react" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-46]** Loosely pinned dependency "form-data": "^4.0.4" uses ^ prefix in dependencies *(Consider pinning "form-data" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-47]** Loosely pinned dependency "ioredis": "^5.8.0" uses ^ prefix in dependencies *(Consider pinning "ioredis" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-48]** Loosely pinned dependency "jose": "^6.1.0" uses ^ prefix in dependencies *(Consider pinning "jose" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-49]** Loosely pinned dependency "jszip": "^3.10.1" uses ^ prefix in dependencies *(Consider pinning "jszip" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-50]** Loosely pinned dependency "lucide-react": "^0.540.0" uses ^ prefix in dependencies *(Consider pinning "lucide-react" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-51]** Loosely pinned dependency "nanoid": "^5.1.5" uses ^ prefix in dependencies *(Consider pinning "nanoid" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-52]** Loosely pinned dependency "openai": "^5.23.1" uses ^ prefix in dependencies *(Consider pinning "openai" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-53]** Loosely pinned dependency "pino": "^9.13.0" uses ^ prefix in dependencies *(Consider pinning "pino" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-54]** Loosely pinned dependency "pino-pretty": "^13.1.1" uses ^ prefix in dependencies *(Consider pinning "pino-pretty" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-55]** Loosely pinned dependency "postgres": "^3.4.7" uses ^ prefix in dependencies *(Consider pinning "postgres" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-56]** Loosely pinned dependency "react-colorful": "^5.6.1" uses ^ prefix in dependencies *(Consider pinning "react-colorful" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-57]** Loosely pinned dependency "react-markdown": "^10.1.0" uses ^ prefix in dependencies *(Consider pinning "react-markdown" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-58]** Loosely pinned dependency "react-syntax-highlighter": "^15.6.6" uses ^ prefix in dependencies *(Consider pinning "react-syntax-highlighter" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-59]** Loosely pinned dependency "recharts": "^3.2.1" uses ^ prefix in dependencies *(Consider pinning "recharts" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-60]** Loosely pinned dependency "remark-gfm": "^4.0.1" uses ^ prefix in dependencies *(Consider pinning "remark-gfm" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-61]** Loosely pinned dependency "shiki": "^3.12.2" uses ^ prefix in dependencies *(Consider pinning "shiki" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-62]** Loosely pinned dependency "streamdown": "^1.0.12" uses ^ prefix in dependencies *(Consider pinning "streamdown" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-63]** Loosely pinned dependency "swr": "^2.3.6" uses ^ prefix in dependencies *(Consider pinning "swr" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-64]** Loosely pinned dependency "tailwind-merge": "^2.5.5" uses ^ prefix in dependencies *(Consider pinning "tailwind-merge" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-65]** Loosely pinned dependency "tsx": "^4.19.2" uses ^ prefix in dependencies *(Consider pinning "tsx" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-66]** Loosely pinned dependency "unsplash-js": "^7.0.20" uses ^ prefix in dependencies *(Consider pinning "unsplash-js" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-67]** Loosely pinned dependency "use-stick-to-bottom": "^1.1.1" uses ^ prefix in dependencies *(Consider pinning "use-stick-to-bottom" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-68]** Loosely pinned dependency "vitest": "^3.2.4" uses ^ prefix in dependencies *(Consider pinning "vitest" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-69]** Loosely pinned dependency "ws": "^8.18.3" uses ^ prefix in dependencies *(Consider pinning "ws" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-70]** Loosely pinned dependency "zod": "^4.1.1" uses ^ prefix in dependencies *(Consider pinning "zod" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-71]** Loosely pinned dependency "@playwright/test": "^1.55.1" uses ^ prefix in devDependencies *(Consider pinning "@playwright/test" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-72]** Loosely pinned dependency "@tailwindcss/postcss": "^4" uses ^ prefix in devDependencies *(Consider pinning "@tailwindcss/postcss" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-73]** Loosely pinned dependency "@testing-library/jest-dom": "^6.9.1" uses ^ prefix in devDependencies *(Consider pinning "@testing-library/jest-dom" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-74]** Loosely pinned dependency "@testing-library/react": "^16.3.0" uses ^ prefix in devDependencies *(Consider pinning "@testing-library/react" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-75]** Loosely pinned dependency "@types/jest": "^30.0.0" uses ^ prefix in devDependencies *(Consider pinning "@types/jest" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-76]** Loosely pinned dependency "@types/node": "^20" uses ^ prefix in devDependencies *(Consider pinning "@types/node" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-77]** Loosely pinned dependency "@types/react": "^19" uses ^ prefix in devDependencies *(Consider pinning "@types/react" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-78]** Loosely pinned dependency "@types/react-dom": "^19" uses ^ prefix in devDependencies *(Consider pinning "@types/react-dom" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-79]** Loosely pinned dependency "@types/react-syntax-highlighter": "^15.5.13" uses ^ prefix in devDependencies *(Consider pinning "@types/react-syntax-highlighter" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-80]** Loosely pinned dependency "@types/supertest": "^6.0.3" uses ^ prefix in devDependencies *(Consider pinning "@types/supertest" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-81]** Loosely pinned dependency "jest": "^30.2.0" uses ^ prefix in devDependencies *(Consider pinning "jest" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-82]** Loosely pinned dependency "jest-environment-jsdom": "^30.2.0" uses ^ prefix in devDependencies *(Consider pinning "jest-environment-jsdom" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-83]** Loosely pinned dependency "redis-memory-server": "^0.13.0" uses ^ prefix in devDependencies *(Consider pinning "redis-memory-server" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-84]** Loosely pinned dependency "supertest": "^7.1.4" uses ^ prefix in devDependencies *(Consider pinning "supertest" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-85]** Loosely pinned dependency "tailwindcss": "^4" uses ^ prefix in devDependencies *(Consider pinning "tailwindcss" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-86]** Loosely pinned dependency "ts-jest": "^29.4.4" uses ^ prefix in devDependencies *(Consider pinning "ts-jest" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-87]** Loosely pinned dependency "tw-animate-css": "^1.3.7" uses ^ prefix in devDependencies *(Consider pinning "tw-animate-css" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-88]** Loosely pinned dependency "typescript": "^5" uses ^ prefix in devDependencies *(Consider pinning "typescript" to an exact version for reproducible builds)*
+- **[dep-pinning-packages-89]** No package-lock.json found. Lock files ensure reproducible installs *(Run "npm install" to generate a package-lock.json)*
+- **[TIMEOUT-openssf-local-checks]** Scanner "openssf-local-checks" timed out after undefinedms *(Increase scannerTimeout in configuration or check network connectivity)*
+- **[TIMEOUT-openssf-scorecard]** Scanner "openssf-scorecard" timed out after undefinedms *(Increase scannerTimeout in configuration or check network connectivity)*
+- **[TIMEOUT-clearly-defined]** Scanner "clearly-defined" timed out after undefinedms *(Increase scannerTimeout in configuration or check network connectivity)*
+- **[license-content-validation-1]** No LICENSE file found in repository root *(Add a LICENSE file with a recognized open source license)*
+- **[TIMEOUT-license-header-scanner]** Scanner "license-header-scanner" timed out after undefinedms *(Increase scannerTimeout in configuration or check network connectivity)*
+- **[vendor-neutrality-high-concentration]** High vendor concentration: ainative.studio (89% of commits) *(Encourage contributions from additional organizations to improve vendor diversity)*
+- **[contributor-funnel-2]** Conversion rates: casual→regular 0%, regular→core 100% *(Low casual-to-regular conversion suggests contributor onboarding friction)*
+- **[psych-safety-1]** No Code of Conduct found *(Add a CODE_OF_CONDUCT.md — see https://www.contributor-covenant.org/)*
+- **[support-channels-1]** No SUPPORT.md or .github/SUPPORT.md found *(Add a SUPPORT.md documenting how users can get help)*
+- **[agentic-rules-2]** CLAUDE.md lacks recognized structural sections *(Add sections like "Critical Rules", "Project Structure", "Common Tasks" to improve agent guidance.)*
+- **[TIMEOUT-ai-repo-detection]** Scanner "ai-repo-detection" timed out after undefinedms *(Increase scannerTimeout in configuration or check network connectivity)*
+- **[TIMEOUT-dataset-provenance]** Scanner "dataset-provenance" timed out after undefinedms *(Increase scannerTimeout in configuration or check network connectivity)*
+- **[TIMEOUT-model-card-detection]** Scanner "model-card-detection" timed out after undefinedms *(Increase scannerTimeout in configuration or check network connectivity)*
+- **[TIMEOUT-model-card-scoring]** Scanner "model-card-scoring" timed out after undefinedms *(Increase scannerTimeout in configuration or check network connectivity)*
+- **[TIMEOUT-diminishing-language-scanner]** Scanner "diminishing-language-scanner" timed out after undefinedms *(Increase scannerTimeout in configuration or check network connectivity)*
+- **[TIMEOUT-inclusive-code-scanner]** Scanner "inclusive-code-scanner" failed: Cannot read properties of undefined (reading 'termListUrl') *(Check scanner implementation for errors)*
+- **[TIMEOUT-inclusive-doc-scanner]** Scanner "inclusive-doc-scanner" failed: Cannot read properties of undefined (reading 'termListUrl') *(Check scanner implementation for errors)*
+- **[TIMEOUT-inclusive-naming-scanner]** Scanner "inclusive-naming-scanner" failed: Cannot read properties of undefined (reading 'termListUrl') *(Check scanner implementation for errors)*
+- **[interaction-templates-1]** No issue templates configured *(Add .github/ISSUE_TEMPLATE/ with bug report and feature request templates)*
+- **[linter-config-1]** No linter configuration found *(Add a linter (ESLint, Prettier, Ruff, golangci-lint, etc.) and configure it to run in CI)*
+
+## Info
+
+- **[branch-protection-1]** GitHub token not provided. Cannot check branch protection settings.
+- **[asset-protection-1]** No trademark policy found (optional)
+- **[asset-protection-2]** No export control documentation found (optional)
+- **[asset-protection-3]** No CLA or DCO requirement detected
+- **[asset-protection-4]** Contributor friction level: Low
+- **[bus-factor-1]** Bus factor: 1, Elephant factor: 89% (2 contributors, 82 commits in last 12 months)
+- **[dep-license-scanning-1]** package.json found but node_modules not installed — cannot scan dependency licenses
+- **[governance-classification-1]** No governance model detected — governance files exist but no recognizable model pattern found
+- **[governance-detection-1]** No governance documentation found
+- **[license-compatibility-1]** Cannot check license compatibility — no LICENSE file found
+- **[vendor-neutrality-domain-count]** Found 2 unique email domain(s) across 82 commits
+- **[vendor-neutrality-no-succession]** No succession planning documentation found
+- **[burnout-detection-1]** Burnout detection requires a GitHub token
+- **[contributor-data-1]** 2 unique contributors with 82 commits in the last 12 months
+- **[contributor-data-2]** Contributor emails span 2 domains
+- **[contributor-funnel-1]** Contributor funnel: 1 core, 1 regular, 0 casual (2 total)
+- **[funding-1]** No funding infrastructure detected
+- **[issue-closure-1]** Issue closure analysis requires a GitHub token
+- **[response-classification-1]** Response classification requires a GitHub token
+- **[response-time-1]** Response time analysis requires a GitHub token
+- **[stale-bot-1]** No stale bot configured
+- **[AK-ACRONYM-ORM-README.md:97]** Undefined acronym "ORM" may confuse newcomers
+- **[AK-ACRONYM-CSRF-README.md:235]** Undefined acronym "CSRF" may confuse newcomers
+- **[AK-ACRONYM-GPT-README.md:257]** Undefined acronym "GPT" may confuse newcomers
+- **[AK-ACRONYM-LICENSE-README.md:279]** Undefined acronym "LICENSE" may confuse newcomers
+- **[release-cadence-1]** No releases or version tags found
+- **[test-coverage-2]** Coverage configuration found: vitest.config.ts
+- **[test-coverage-3]** No coverage badge found in README
+- **[semver-validation-1]** No git tags found — cannot validate SemVer
+
+## Recommendations
+
+- **[HIGH impact / medium effort]** Add a LICENSE file to the repository root. Visit https://choosealicense.com/ for guidance.
+  - https://choosealicense.com/
+- **[MEDIUM impact / low effort]** Increase scannerTimeout in configuration or check network connectivity
+- **[MEDIUM impact / low effort]** Consider pinning "@ai-sdk/openai" to an exact version for reproducible builds
+- **[MEDIUM impact / low effort]** Increase scannerTimeout in configuration or check network connectivity
+- **[MEDIUM impact / low effort]** Add a LICENSE file with a recognized open source license
+- **[MEDIUM impact / low effort]** Encourage contributions from additional organizations to improve vendor diversity
+- **[MEDIUM impact / low effort]** Low casual-to-regular conversion suggests contributor onboarding friction
+- **[MEDIUM impact / low effort]** Add a CODE_OF_CONDUCT.md — see https://www.contributor-covenant.org/
+- **[MEDIUM impact / low effort]** Add a SUPPORT.md documenting how users can get help
+- **[MEDIUM impact / low effort]** Add sections like "Critical Rules", "Project Structure", "Common Tasks" to improve agent guidance.
+- **[MEDIUM impact / low effort]** Increase scannerTimeout in configuration or check network connectivity
+- **[MEDIUM impact / low effort]** Increase scannerTimeout in configuration or check network connectivity
+- **[MEDIUM impact / low effort]** Check scanner implementation for errors
+- **[MEDIUM impact / low effort]** Add .github/ISSUE_TEMPLATE/ with bug report and feature request templates
+- **[MEDIUM impact / low effort]** Add a linter (ESLint, Prettier, Ruff, golangci-lint, etc.) and configure it to run in CI
+
+## Score Rationale
+
+Overall score is a weighted sum of six pillar scores (each scored 0–10).
+
+| Pillar | Weight | Raw Score | Contribution |
+|--------|--------|-----------|-------------|
+| Security | 25% | 0.0 | 0.00 |
+| Governance | 20% | 0.0 | 0.00 |
+| Community | 15% | 1.0 | 0.15 |
+| AI Readiness | 15% | 2.5 | 0.38 |
+| Inclusive Language | 15% | 2.0 | 0.30 |
+| Technical Rigor | 10% | 5.0 | 0.50 |
+| **Overall** | **100%** | | **1.30** |
+
+---
+*quaid-scanner v0.1.2 | 2026-06-01T21:25:11.219Z*
+*Commit: cf51242eb3d79a7bfd6e75295bc3cb2c388fcaa6*


### PR DESCRIPTION
## OSS Health Report — 2026-06-01

**Score:** ?/10 | **Risk:** ? | **Depth:** standard

Generated by [quaid-scanner](https://github.com/quaid/quaid-scanner) v0.1.2.

Report lives at `docs/reports/quaid-scan-2026-06-01.md`.
Issues for CRITICAL and WARNING findings are filed separately in this repo.