### PR TITLE
[FEATURE] Agent recall + cross-product learning via ZeroMemory

### DIFF
--- a/lib/agent/metrics.ts
+++ b/lib/agent/metrics.ts
@@ -83,6 +83,8 @@ export class MetricsCollector {
   private subagentMetrics: Map<string, SubagentMetrics>
   private startTime: number
 
+  private templateId?: string
+
   constructor(sessionId: string, userPrompt: string, model: string, userId?: string, chatId?: string) {
     this.sessionId = sessionId
     this.userId = userId
@@ -97,6 +99,13 @@ export class MetricsCollector {
       userId: this.userId,
       chatId: this.chatId,
     })
+  }
+
+  /**
+   * Set the template/prompt version used for this generation (Refs #43)
+   */
+  setTemplateId(templateId: string): void {
+    this.templateId = templateId
   }
 
   /**
@@ -207,6 +216,7 @@ export class MetricsCollector {
         designMetadata: designMetrics?.metadata,
         codeMetadata: codeMetrics?.metadata,
         validationMetadata: validationMetrics?.metadata,
+        templateId: this.templateId,
       },
     }
   }
@@ -374,6 +384,7 @@ export class MetricsCollector {
               codeTime: metrics.codeTime,
               validationTime: metrics.validationTime,
               totalTokens: metrics.tokenUsage?.total?.totalTokens,
+              templateId: this.templateId,
               source: 'builder.ainative.studio',
             },
           }),

--- a/lib/agent/multi-pass-generator.ts
+++ b/lib/agent/multi-pass-generator.ts
@@ -10,6 +10,7 @@ import { ChunkPlan, ChunkPhase } from './chunk-planner'
 import { extractComponentCode } from './component-generation-tool'
 import { validateGeneratedCode } from '../code-validator'
 import { PROFESSIONAL_SYSTEM_PROMPT } from '../professional-prompt'
+import { recallPastPerformance, storeGenerationMemory } from './zeromemory'
 
 export interface GeneratedChunk {
   chunkId: string
@@ -43,6 +44,14 @@ export async function executeChunkPlan(
 ): Promise<GeneratedChunk[]> {
   const chunks: GeneratedChunk[] = []
   const totalPhases = plan.phases.length
+
+  // Recall past performance for similar prompts (Refs #43)
+  const firstPrompt = plan.phases[0]?.prompt || ''
+  const pastLearnings = await recallPastPerformance(firstPrompt)
+  if (pastLearnings) {
+    // Inject past learnings into phase 1 prompt so the LLM benefits
+    plan.phases[0].prompt = `Past learnings for similar requests:\n${pastLearnings}\n\n${plan.phases[0].prompt}`
+  }
 
   onProgress(0, totalPhases, 'Starting multi-phase generation...')
 
@@ -104,6 +113,16 @@ export async function executeChunkPlan(
     successCount: chunks.filter(c => c.success).length,
     totalChunks: chunks.length
   })
+
+  // Store generation result for cross-product learning (Refs #43)
+  const successCount = chunks.filter(c => c.success).length
+  const allSuccess = successCount === chunks.length
+  const quality = chunks.length > 0 ? successCount / chunks.length : 0
+  storeGenerationMemory(firstPrompt.slice(0, 300), allSuccess, quality, {
+    source: 'multi-pass-generator',
+    totalPhases: chunks.length,
+    successCount,
+  }).catch(() => {})
 
   return chunks
 }

--- a/lib/agent/subagents.ts
+++ b/lib/agent/subagents.ts
@@ -6,6 +6,7 @@ import {
   loadAgentProfiles,
 } from './agent-profiles'
 import { createMetricsCollector, extractTokenUsage, MetricsCollector } from './metrics'
+import { recallPastPerformance, storeGenerationMemory } from './zeromemory'
 
 /**
  * Subagents Architecture (US-025)
@@ -320,12 +321,22 @@ export async function runOrchestratorAgent(
   console.log('\n👔 CODY (Team Leader): Alright team, we have a new component to build. Let\'s do this right.\n')
   console.log(`📋 Mission: "${userPrompt}"\n`)
 
+  // Recall past performance for similar prompts (Refs #43)
+  const pastLearnings = await recallPastPerformance(userPrompt)
+  const enrichedMemoryContext = pastLearnings
+    ? `Past learnings for similar requests:\n${pastLearnings}\n\n${memoryContext}`
+    : memoryContext
+
+  if (pastLearnings) {
+    console.log('📚 CODY: Found past learnings from similar builds. Injecting into context.\n')
+  }
+
   // Step 1: Design Subagent analyzes requirements
   console.log('👔 CODY: Design team, analyze the requirements and give me a solid spec.')
   console.log('🎨 [1/3] Design Agents (ai-product-architect + system-architect): On it, Cody...\n')
 
   metricsCollector.startSubagent('design')
-  const designResult = await runDesignSubagent(userPrompt, memoryContext)
+  const designResult = await runDesignSubagent(userPrompt, enrichedMemoryContext)
   metricsCollector.endSubagent(
     'design',
     designResult.success,
@@ -405,6 +416,15 @@ export async function runOrchestratorAgent(
 
   // Complete metrics collection and publish
   const metrics = await metricsCollector.complete()
+
+  // Store generation result for cross-product learning (Refs #43)
+  const quality = validationResult.success ? 0.85 : 0.3
+  storeGenerationMemory(userPrompt, validationResult.success, quality, {
+    sessionId: sessionId || `session-${Date.now()}`,
+    model,
+    totalTime: metrics.totalTime,
+    totalTokens: metrics.tokenUsage?.total?.totalTokens,
+  }).catch(() => {})
 
   return {
     designSpec: designResult.output,

--- a/lib/agent/zeromemory.ts
+++ b/lib/agent/zeromemory.ts
@@ -1,0 +1,93 @@
+/**
+ * ZeroMemory Integration for Agent Recall + Cross-Product Learning (Refs #43)
+ *
+ * Best-effort recall/store — NEVER blocks generation.
+ * Uses the ZeroDB/ZeroMemory public API for semantic memory.
+ */
+
+import { logger } from '../logger'
+
+function getMemoryConfig() {
+  const apiUrl = process.env.AINATIVE_API_URL || process.env.NEXT_PUBLIC_API_BASE || 'https://api.ainative.studio'
+  const apiKey = process.env.ZERODB_API_KEY || process.env.AINATIVE_API_KEY || ''
+  return { apiUrl, apiKey }
+}
+
+/**
+ * Recall past performance data for similar prompts.
+ * Returns a string of past learnings to inject as context, or empty string.
+ */
+export async function recallPastPerformance(userPrompt: string): Promise<string> {
+  try {
+    const { apiUrl, apiKey } = getMemoryConfig()
+    if (!apiKey) return ''
+
+    const res = await fetch(`${apiUrl}/api/v1/public/memory/v2/recall`, {
+      method: 'POST',
+      headers: { 'x-api-key': apiKey, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        query: userPrompt,
+        limit: 3,
+        tags: ['builder', 'rlhf'],
+      }),
+      signal: AbortSignal.timeout(3000),
+    })
+    if (!res.ok) return ''
+
+    const data = await res.json()
+    const memories = data.memories || data.results || []
+    if (memories.length === 0) return ''
+
+    const context = memories
+      .map((m: any) => m.content || m.text || '')
+      .filter(Boolean)
+      .join('\n')
+
+    if (context) {
+      logger.info('Recalled past performance context', {
+        memoryCount: memories.length,
+        contextLength: context.length,
+      })
+    }
+
+    return context
+  } catch {
+    return ''
+  }
+}
+
+/**
+ * Store a successful (or failed) generation as a searchable memory
+ * for cross-product learning. Fire-and-forget.
+ */
+export async function storeGenerationMemory(
+  prompt: string,
+  success: boolean,
+  quality: number,
+  metadata?: Record<string, any>
+): Promise<void> {
+  try {
+    const { apiUrl, apiKey } = getMemoryConfig()
+    if (!apiKey) return
+
+    await fetch(`${apiUrl}/api/v1/public/memory/v2/remember`, {
+      method: 'POST',
+      headers: { 'x-api-key': apiKey, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        content: `Builder generation: "${prompt.slice(0, 200)}" — ${success ? 'succeeded' : 'failed'}, quality=${quality.toFixed(2)}`,
+        tags: ['builder', 'generation', success ? 'success' : 'failure', 'rlhf'],
+        importance: success ? 0.4 : 0.7,
+        metadata: {
+          prompt: prompt.slice(0, 500),
+          success,
+          quality,
+          source: 'builder.ainative.studio',
+          ...metadata,
+        },
+      }),
+      signal: AbortSignal.timeout(5000),
+    }).catch(() => {})
+  } catch {
+    // Best-effort — never block generation
+  }
+}


### PR DESCRIPTION
## Summary
- Adds ZeroMemory recall before generation starts — agents learn from past similar builds
- Stores generation outcomes (success/failure, quality score) after completion for cross-product learning
- Adds templateId tracking to MetricsCollector for prompt version analytics
- All ZeroMemory calls are best-effort with timeouts (3s recall, 5s store) — never blocks generation

## Files changed
- `lib/agent/zeromemory.ts` — new: recallPastPerformance() + storeGenerationMemory()
- `lib/agent/subagents.ts` — recall before design, store after orchestrator completes
- `lib/agent/multi-pass-generator.ts` — recall before phase 1, store after all phases
- `lib/agent/metrics.ts` — templateId field + setter on MetricsCollector, included in ZeroMemory metadata

## Test plan
- [ ] TypeScript compiles clean (verified — no new errors)
- [ ] Generate a component with ZERODB_API_KEY set — confirm recall runs without blocking
- [ ] Generate without ZERODB_API_KEY — confirm graceful no-op
- [ ] Verify stored memories appear in ZeroDB with correct tags

Closes #43