### PR TITLE
[BUG] Fix /api/health 502 — liveness vs readiness split

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -8,27 +8,27 @@ export const runtime = 'nodejs'
 /**
  * Health check endpoint for production monitoring
  *
- * Returns:
- * - 200: System is healthy
- * - 503: System is degraded or unhealthy
+ * Liveness check (default): Always returns 200 if the process is running.
+ * Readiness check (?ready=1): Returns 503 if dependencies (DB) are down.
  *
- * Metrics included:
- * - Database connectivity
- * - Redis connectivity (if configured)
- * - Error rates (5min, 1hour, 24hour)
- * - System uptime
- * - Response times
+ * Railway, uptime monitors, and issue #39 health probes hit this endpoint.
+ * A liveness probe must never fail due to a transient DB hiccup.
  */
-export async function GET() {
+export async function GET(request: Request) {
   try {
+    const { searchParams } = new URL(request.url)
+    const readinessCheck = searchParams.get('ready') === '1'
+
     const health = await monitoring.checkSystemHealth()
 
-    const statusCode = health.status === 'healthy' ? 200 : 503
+    // Liveness: 200 always. Readiness: 503 if unhealthy.
+    const statusCode =
+      readinessCheck && health.status !== 'healthy' ? 503 : 200
 
     logger.info('Health check performed', {
       status: health.status,
       database: health.database.status,
-      errors: health.errors,
+      readinessCheck,
     })
 
     return NextResponse.json(
@@ -50,7 +50,7 @@ export async function GET() {
         },
         errors: health.errors,
         environment: process.env.NODE_ENV,
-        version: process.env.VERCEL_GIT_COMMIT_SHA || 'unknown',
+        version: process.env.RAILWAY_GIT_COMMIT_SHA || process.env.VERCEL_GIT_COMMIT_SHA || 'unknown',
       },
       { status: statusCode }
     )
@@ -64,7 +64,7 @@ export async function GET() {
         error: 'Health check failed',
         message: error instanceof Error ? error.message : 'Unknown error',
       },
-      { status: 503 }
+      { status: 200 }
     )
   }
 }


### PR DESCRIPTION
## Summary
- The `/api/health` endpoint was returning **503** whenever the database connection failed, causing Railway and uptime monitors to report the builder as down
- The app itself was healthy (root `/` returned 200, uptime 2058s) — only the health probe was failing due to a strict DB dependency check
- Split into **liveness** (default, always 200) and **readiness** (`?ready=1`, returns 503 if DB is down)
- Also updated version env var to check `RAILWAY_GIT_COMMIT_SHA` first (was only checking Vercel)

## Root cause
`monitoring.checkSystemHealth()` runs `SELECT 1` against the DB. When the DB connection is unavailable (pool exhaustion, transient network issue), the health endpoint returned 503, making Railway think the service was down.

## Test plan
- [ ] `curl https://builder.ainative.studio/api/health` returns 200 with status metadata
- [ ] `curl https://builder.ainative.studio/api/health?ready=1` returns 503 if DB is disconnected, 200 if connected
- [ ] Railway health checks stop alerting after deploy

Closes #39