### PR TITLE
fix(rlhf): repair export route + capture tokens & user_id for BW-1 pipeline

### DIFF
--- a/app/api/chat-ws/route.ts
+++ b/app/api/chat-ws/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest } from 'next/server'
+import { getToken } from 'next-auth/jwt'
 import OpenAI from 'openai'
 import { nanoid } from 'nanoid'
 import { verifyAndEnhancePrompt } from '@/lib/component-verifier'
@@ -107,6 +108,21 @@ export async function POST(request: NextRequest) {
 
     if (!message) {
       return Response.json({ error: 'Message is required' }, { status: 400 })
+    }
+
+    // Resolve the authenticated user so RLHF training rows carry real
+    // attribution instead of 'anonymous' (#61). Falls back to 'anonymous'
+    // for true guests / unauthenticated requests.
+    let userId = 'anonymous'
+    try {
+      const token = await getToken({
+        req: request,
+        secret: process.env.AUTH_SECRET,
+        secureCookie: process.env.NODE_ENV === 'production',
+      })
+      if (token?.sub || token?.email) userId = String(token.sub || token.email)
+    } catch (_) {
+      // best-effort — never block generation on auth resolution
     }
 
     // Get previous messages if this is a continuation
@@ -397,7 +413,7 @@ export async function POST(request: NextRequest) {
               // Log primary agent run (fire-and-forget)
               logAgentRun({
                 chatId: responseId,
-                userId: 'anonymous',
+                userId,
                 model: requestedModel || 'sonnet',
                 turns: agentTurns,
                 toolsUsed: agentToolsUsed,
@@ -416,7 +432,7 @@ export async function POST(request: NextRequest) {
                 // Log failed primary agent run (fire-and-forget)
                 logAgentRun({
                   chatId: responseId,
-                  userId: 'anonymous',
+                  userId,
                   model: requestedModel || 'sonnet',
                   turns: agentTurns,
                   toolsUsed: agentToolsUsed,
@@ -639,6 +655,9 @@ OUTPUT: Generate 150-300 lines of COMPLETE, working code. Make it visually polis
                   max_tokens: 16000,
                   temperature: 0.7,
                   stream: true,
+                  // Ask the provider to emit a final usage chunk so we can
+                  // record token counts for RLHF training data (#61).
+                  stream_options: { include_usage: true },
                 })
 
                 for await (const chunk of stream) {
@@ -650,6 +669,17 @@ OUTPUT: Generate 150-300 lines of COMPLETE, working code. Make it visually polis
                     if (now - lastUpdateTime > 500) {
                       safeEnqueue(encoder.encode(`data: ${JSON.stringify({ type: 'refresh' })}\n\n`))
                       lastUpdateTime = now
+                    }
+                  }
+                  // The usage chunk arrives last with empty choices.
+                  if (chunk.usage) {
+                    const inTok = chunk.usage.prompt_tokens || 0
+                    const outTok = chunk.usage.completion_tokens || 0
+                    tokenUsage = {
+                      input_tokens: inTok,
+                      output_tokens: outTok,
+                      total_tokens: chunk.usage.total_tokens || inTok + outTok,
+                      estimated_cost: (inTok * 0.003 + outTok * 0.015) / 1000,
                     }
                   }
                 }
@@ -666,6 +696,16 @@ OUTPUT: Generate 150-300 lines of COMPLETE, working code. Make it visually polis
                   ],
                 })
                 fullContent = fallbackResponse.choices?.[0]?.message?.content || ''
+                if (fallbackResponse.usage) {
+                  const inTok = fallbackResponse.usage.prompt_tokens || 0
+                  const outTok = fallbackResponse.usage.completion_tokens || 0
+                  tokenUsage = {
+                    input_tokens: inTok,
+                    output_tokens: outTok,
+                    total_tokens: fallbackResponse.usage.total_tokens || inTok + outTok,
+                    estimated_cost: (inTok * 0.003 + outTok * 0.015) / 1000,
+                  }
+                }
               }
             } else if (!fullContent || fullContent.length <= 500) {
               // AINative: single-turn generation (system+user only)
@@ -703,6 +743,20 @@ OUTPUT: Generate 150-300 lines of COMPLETE, working code. Make it visually polis
                   const tokens = response.usage?.completion_tokens || 0
                   const finish = response.choices?.[0]?.finish_reason
                   console.log(`📊 ${tryModel}: ${fullContent.length} chars (${tokens} tok) finish=${finish}`)
+
+                  // Capture token usage for RLHF training data (#61) — the
+                  // single-turn path returns usage but never recorded it, so
+                  // ~97% of rows had zero tokens.
+                  if (response.usage) {
+                    const inTok = response.usage.prompt_tokens || 0
+                    const outTok = response.usage.completion_tokens || 0
+                    tokenUsage = {
+                      input_tokens: inTok,
+                      output_tokens: outTok,
+                      total_tokens: response.usage.total_tokens || inTok + outTok,
+                      estimated_cost: (inTok * 0.003 + outTok * 0.015) / 1000,
+                    }
+                  }
 
                   // Handle truncation: if finish_reason=length, close the component
                   if (finish === 'length' && fullContent.length > 500) {
@@ -944,7 +998,7 @@ The component MUST have \`export default function App()\` or \`export default Ap
             // Log fallback agent run (fire-and-forget)
             logAgentRun({
               chatId: responseId,
-              userId: 'anonymous',
+              userId,
               model: 'sonnet',
               turns: 0, // fallback is single-shot fix
               toolsUsed: ['Write'],
@@ -1149,7 +1203,7 @@ The component MUST have \`export default function App()\` or \`export default Ap
               console.log('[RLHF] 🔄 Calling logGenToDrizzle for', responseId)
               logGenToDrizzle({
                 chatId: responseId,
-                userId: 'anonymous', // TODO: get from session
+                userId, // resolved from session/JWT above (#61)
                 prompt: message,
                 generatedCode: finalContent,
                 model: usedModel,
@@ -1210,7 +1264,7 @@ The component MUST have \`export default function App()\` or \`export default Ap
           import('@/lib/services/rlhf.service').then(({ logGenerationFailure }) => {
             logGenerationFailure({
               chatId: responseId,
-              userId: 'anonymous',
+              userId,
               prompt: message,
               model: requestedModel || DEFAULT_MODEL,
               error: error instanceof Error ? error.message : String(error),

--- a/app/api/rlhf/export/route.ts
+++ b/app/api/rlhf/export/route.ts
@@ -33,46 +33,68 @@ export async function GET(request: NextRequest) {
     const statusFilter = url.searchParams.get('status')
     const limit = Math.min(parseInt(url.searchParams.get('limit') || '1000'), 10000)
 
-    // Query ZeroDB for training data
+    // Query ZeroDB for training data.
+    // NOTE: use the same contract as the write + insights paths
+    // (lib/services/zerodb-rlhf.service.ts) — base api.ainative.studio,
+    // path /api/v1/projects/{id}/database/tables/{table}/rows, x-api-key auth,
+    // response shape data[].row_data. The old api.zerodb.ai/query/Bearer
+    // contract never matched the live API and silently returned empty (#60).
     const apiKey = process.env.ZERODB_API_KEY || process.env.AINATIVE_API_KEY || ''
-    const projectId = process.env.ZERODB_PROJECT_ID || ''
+    const projectId = process.env.ZERODB_PROJECT_ID || '5dfbc60c-7463-4e21-ac68-9bbe536f9adf'
 
     if (!apiKey || !projectId) {
       return Response.json({ error: 'ZeroDB not configured' }, { status: 500 })
     }
 
-    const baseUrl = process.env.ZERODB_BASE_URL || 'https://api.zerodb.ai'
+    const baseUrl =
+      process.env.AINATIVE_API_URL || process.env.ZERODB_BASE_URL || 'https://api.ainative.studio'
+    const tablesUrl = `${baseUrl}/api/v1/projects/${projectId}/database/tables`
+    const zeroHeaders = { 'x-api-key': apiKey, 'Content-Type': 'application/json' }
+
     const sinceDate = new Date()
     sinceDate.setDate(sinceDate.getDate() - days)
 
-    // Build query filters
-    const filters: Record<string, any> = {
-      created_at: { $gte: sinceDate.toISOString() },
-    }
-    if (modelFilter) filters.model = modelFilter
-    if (statusFilter) filters.status = statusFilter
-
-    const response = await fetch(`${baseUrl}/v1/tables/${projectId}/rlhf_training_data/query`, {
-      method: 'POST',
-      headers: {
-        'Authorization': `Bearer ${apiKey}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        filters,
-        limit,
-        sort: { created_at: 'desc' },
-      }),
+    // Pull training rows (fetch generously, filter client-side to mirror insights path).
+    const fetchLimit = Math.min(Math.max(limit, 500), 10000)
+    const trainingRes = await fetch(
+      `${tablesUrl}/rlhf_training_data/rows?limit=${fetchLimit}`,
+      { method: 'GET', headers: zeroHeaders, signal: AbortSignal.timeout(30_000) },
+    ).catch((e) => {
+      console.warn('[RLHF Export] training fetch threw:', (e as Error)?.name || e)
+      return null
     })
 
-    if (!response.ok) {
-      // Table might not exist yet — return empty
-      console.warn('[RLHF Export] Query failed:', response.status)
+    if (!trainingRes || !trainingRes.ok) {
+      console.warn('[RLHF Export] Query failed:', trainingRes?.status)
       return exportResponse([], format)
     }
 
-    const data = await response.json()
-    const rows = data.rows || data.data || []
+    const data = await trainingRes.json()
+    const allRows = (data?.data || []).map((r: any) => r.row_data || r)
+
+    // Build chat_id -> rating map from the feedback table so min_rating actually filters.
+    const ratingMap = new Map<string, number>()
+    if (minRating !== null) {
+      const fbRes = await fetch(
+        `${tablesUrl}/rlhf_feedback/rows?limit=${fetchLimit}`,
+        { method: 'GET', headers: zeroHeaders, signal: AbortSignal.timeout(30_000) },
+      ).catch(() => null)
+      if (fbRes?.ok) {
+        const fb = await fbRes.json()
+        for (const r of (fb?.data || []).map((x: any) => x.row_data || x)) {
+          if (r.chat_id && typeof r.rating === 'number') ratingMap.set(r.chat_id, r.rating)
+        }
+      }
+    }
+
+    // Apply date + model + status filters client-side.
+    const rows = allRows.filter((r: any) => {
+      const created = r.created_at ? new Date(r.created_at) : null
+      if (!created || created < sinceDate) return false
+      if (modelFilter && r.model !== modelFilter) return false
+      if (statusFilter && (r.status || 'success') !== statusFilter) return false
+      return true
+    })
 
     // Transform to fine-tuning format
     let trainingData = rows.map((row: any) => {
@@ -119,15 +141,18 @@ export async function GET(request: NextRequest) {
           provider: row.provider,
           input_tokens: row.input_tokens,
           output_tokens: row.output_tokens,
+          total_tokens: row.total_tokens,
           created_at: row.created_at,
+          rating: ratingMap.get(row.chat_id) ?? null,
         },
       }
     })
 
-    // Filter by rating if requested (requires feedback correlation)
+    // Filter by rating if requested — real join against the feedback table (#60).
     if (minRating !== null) {
-      // For now, filter by status — rated data requires join with feedback table
-      trainingData = trainingData.filter((d: any) => d.metadata.status === 'success')
+      trainingData = trainingData.filter(
+        (d: any) => d.metadata.rating !== null && d.metadata.rating >= minRating,
+      )
     }
 
     return exportResponse(trainingData, format)


### PR DESCRIPTION
## Summary
Fixes the two code-level gaps found during BW-1 RLHF pipeline validation (2026-07-18). The capture pipeline itself is confirmed working (a live generation round-tripped into all 3 ZeroDB tables); these fixes address data completeness and the export path.

## Changes

### 1. Export route — was silently broken (#60)
`/api/rlhf/export` used a ZeroDB contract that never matched the live API, so every call returned empty. This is the tool used to pull JSONL for BW-1 fine-tuning.

| | Before (broken) | After (fixed) |
|---|---|---|
| Base URL | `api.zerodb.ai` | `api.ainative.studio` |
| Path | `/v1/tables/{id}/…/query` | `/api/v1/projects/{id}/database/tables/…/rows` |
| Auth | `Bearer` | `x-api-key` |
| Response | `data.rows` | `data[].row_data` |
| `min_rating` | faked (status only) | real join vs `rlhf_feedback` |

Verified against live ZeroDB: 137 rows, valid OpenAI chat-completion JSONL.

### 2. Token + user_id capture on fast path (#61)
- **Tokens:** single-turn, Meta-streaming (`stream_options.include_usage`), and non-streaming fallback now all populate `input/output/total_tokens`. Previously ~97% of rows (132/136) had zero tokens.
- **user_id:** resolved once from the session JWT (`getToken`) and threaded into every RLHF/agent-run log call; falls back to `anonymous` only for true guests. Previously hardcoded.

## Testing
- `tsc --noEmit` clean on both touched files (pre-existing test-file errors unrelated).
- Live ZeroDB contract verification for export (137 rows → JSONL).
- Live `/api/chat-ws` generation confirmed writing to `rlhf_training_data`, `rlhf_feedback`, `generations`.

Closes #60
Closes #61
Refs #62 (traffic-gap investigation — tracking only)