### PR TITLE
fix(codegen): repair malformed ternaries that broke Sandpack previews (#64)

### DIFF
--- a/__tests__/lib/code-validator-duplicates.test.ts
+++ b/__tests__/lib/code-validator-duplicates.test.ts
@@ -115,3 +115,45 @@ describe('code-validator: duplicate declaration handling (#64)', () => {
     expect(findDuplicateTopLevelDeclaration(code)).toBe('UICard')
   })
 })
+
+/**
+ * Same class of defect surfaced by the #64 regression run: a stray semicolon
+ * splitting a ternary (accepted by Babel errorRecovery, fatal in Sandpack →
+ * "Unexpected token, expected ':'"). Must be auto-fixed to strict-valid, or
+ * rejected so the retry path re-generates — never a false 'success' that breaks.
+ */
+describe('code-validator: malformed ternary handling (#64 follow-up)', () => {
+  const strictParses = (code: string) => {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      require('@babel/parser').parse(code, { sourceType: 'module', plugins: ['jsx', 'typescript'] })
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  const badCases: Record<string, string> = {
+    'stray ; before the ternary colon': "export default function App(){ const v = c ? 'a'\n : 'b';\n return <div className={v}/>; }",
+    'stray ; after the true branch': "export default function App(){ const v =\n c ? 'x';\n : '';\n return <div className={v}/>; }",
+    'stray ; before the question mark': "export default function App(){ const v = c;\n ? 'a'\n : 'b';\n return <div className={v}/>; }",
+  }
+
+  for (const [name, code] of Object.entries(badCases)) {
+    it(`${name}: never a false success`, () => {
+      const r = validateJavaScriptCode(code)
+      // Either fixed (parses strictly) or explicitly invalid so retry engages.
+      expect(r.valid === false || strictParses(r.code)).toBe(true)
+    })
+  }
+
+  it('valid ternary still passes', () => {
+    const code = "export default function App(){ const v = c ? 'a' : 'b'; return <div className={v}/>; }"
+    expect(validateJavaScriptCode(code).valid).toBe(true)
+  })
+
+  it('JSX-recoverable code is not falsely rejected', () => {
+    const code = "export default function App(){ return (<div><p>Hello & welcome</p></div>); }"
+    expect(validateJavaScriptCode(code).valid).toBe(true)
+  })
+})

--- a/lib/code-validator.ts
+++ b/lib/code-validator.ts
@@ -120,6 +120,17 @@ function autoFixCode(code: string): { code: string; fixes: string[] } {
   // Model sometimes generates: const x = condition ; ? 'yes' : 'no'
   fixedCode = fixedCode.replace(/\s*;\s*\?\s/g, ' ? ')
 
+  // Fix TERNARY (stray semicolon splitting a ?: expression): the model emits a
+  // `;` between the condition/true-branch and the following `?` or `:`, which
+  // Babel's errorRecovery parse accepts but Sandpack rejects with
+  // "Unexpected token, expected ':'". Drop a `;` that directly precedes a line
+  // whose first non-space char is `?` or `:` (a dangling ternary continuation).
+  const beforeTernBranchFix = fixedCode
+  fixedCode = fixedCode.replace(/;\s*(\n\s*[?:]\s)/g, '$1')
+  if (fixedCode !== beforeTernBranchFix) {
+    fixes.push('Removed stray semicolon splitting a ternary expression')
+  }
+
   // Fix CONTINUATION DUPLICATION: Remove duplicate jsx markers from continuation stitching
   // e.g. ```jsx appearing mid-code from continuation
   fixedCode = fixedCode.replace(/```jsx?\s*\n/g, (match, offset) => {
@@ -411,6 +422,44 @@ export function validateJavaScriptCode(code: string): ValidationResult {
       allowAwaitOutsideFunction: true,
       allowSuperOutsideMethod: true,
     })
+
+    // The errorRecovery parse passed. Sandpack (the real runtime) uses a STRICT
+    // transform, so run a second strict parse to catch a narrow class of errors
+    // that errorRecovery hides but Sandpack rejects — chiefly malformed ternaries
+    // (stray `;` splitting `?:`) that render as "Something went wrong". Only these
+    // specific errors are rejected, so JSX-recoverable cases still pass (builder#64).
+    try {
+      parse(fixedCode, {
+        sourceType: 'module',
+        plugins: ['jsx', 'typescript'],
+        errorRecovery: false,
+        allowReturnOutsideFunction: true,
+        allowAwaitOutsideFunction: true,
+        allowSuperOutsideMethod: true,
+      })
+    } catch (strictError) {
+      const strictMsg =
+        strictError instanceof Error ? strictError.message.replace(/\(\d+:\d+\)/, '').trim() : ''
+      const s = strictMsg.toLowerCase()
+      // Sandpack-fatal token errors: a ternary/expression expecting ':' or a
+      // definite "unexpected token, expected X" mismatch. Exclude the benign
+      // "missing semicolon" recovery hint (Sandpack tolerates that).
+      const isSandpackFatal =
+        (s.includes('expected ":"') || s.includes("expected ':'")) ||
+        (s.includes('unexpected token, expected') && !s.includes('missing semicolon'))
+      if (isSandpackFatal) {
+        console.error('❌ Code validation failed (strict parse — Sandpack-fatal):', strictMsg)
+        return {
+          valid: false,
+          error: strictMsg,
+          code: fixedCode,
+          autoFixed: fixes.length > 0,
+          fixes: fixes.length > 0 ? fixes : undefined,
+        }
+      }
+      // Any other strict-only error: let it through (browser/Sandpack Babel is
+      // lenient enough), preserving the original permissive behavior.
+    }
 
     // Success - return fixed code
     return {


### PR DESCRIPTION
## Problem
Follow-up to #65. The live #64 regression run surfaced a **second** invalid-output class (2/3 gens clean, 1 broke): the model emits a stray semicolon splitting a ternary —

```js
const variantClasses =
  variant === 'outline';      // ← stray ; (or after true-branch, or before ?)
    ? 'border ...'
    : ''
```

Babel's `errorRecovery` parse accepts it (row logs `status=success`), but Sandpack rejects it: `Unexpected token, expected ':' (392:6)` → "Something went wrong" preview.

## Fix (`lib/code-validator.ts`)
1. Auto-fix a `;` that directly precedes a dangling `?`/`:` ternary continuation line.
2. **Strict-parse backstop**: after the permissive errorRecovery parse, run a strict (no-recovery) parse and reject only the narrow Sandpack-fatal token family (`expected ':'` / definite `unexpected token, expected`). This mirrors Sandpack's real behavior, so the existing retry re-generates and RLHF logs `validation_error` — while JSX-recoverable code still passes untouched.

## Tests (13 total, all green)
- 3 stray-semicolon ternary variants → each auto-fixed to strict-valid or rejected (never a false success)
- No-false-positive guards: valid ternary passes, JSX with `&`/`<` entities passes
- All 8 duplicate-declaration tests from #65 still green

## Verification
- `tsc --noEmit` clean
- Reproduced the exact prod failure shape; confirmed fixed

Refs #64