### PR TITLE
fix(codegen): import injector no longer creates cross-module duplicates (#64)

### DIFF
--- a/__tests__/lib/multi-file-import-injection.test.ts
+++ b/__tests__/lib/multi-file-import-injection.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { parseMultiFileOutput } from '@/lib/multi-file-parser'
+
+const strictParses = (code: string) => {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    require('@babel/parser').parse(code, { sourceType: 'module', plugins: ['jsx', 'typescript'] })
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * builder#64 true root cause: injectMissingImports re-added names (LineChart,
+ * BarChart, PieChart exist in BOTH lucide-react and recharts) that were already
+ * imported from another module, producing "Identifier 'X' has already been
+ * declared" in Sandpack — downstream of the code-validator's de-dupe.
+ */
+describe('multi-file import injection: no cross-module duplicates (#64)', () => {
+  it('does not re-inject a name already imported from recharts', () => {
+    const raw = [
+      "import React from 'react'",
+      "import { ResponsiveContainer, LineChart, Line, BarChart, Bar } from 'recharts'",
+      'export default function App(){',
+      '  return <div><LineChart><Line/></LineChart><BarChart><Bar/></BarChart></div>;',
+      '}',
+    ].join('\n')
+    const app = Object.values(parseMultiFileOutput(raw))[0]
+    expect(
+      /import\s*\{[^}]*\bLineChart\b[^}]*\}\s*from\s*['"]lucide-react['"]/.test(app),
+    ).toBe(false)
+    expect(strictParses(app)).toBe(true)
+  })
+
+  it('does not re-inject an AIKit component already imported', () => {
+    const raw = [
+      "import React from 'react'",
+      "import { MetricCard } from './components/aikit'",
+      'export default function App(){ return <MetricCard/>; }',
+    ].join('\n')
+    const app = Object.values(parseMultiFileOutput(raw))[0]
+    // MetricCard must be imported exactly once
+    const count = (app.match(/\bMetricCard\b(?=[\s,}])/g) || []).length
+    expect(count).toBe(1)
+    expect(strictParses(app)).toBe(true)
+  })
+
+  it('still injects genuinely-missing lucide icons', () => {
+    const raw = [
+      "import React from 'react'",
+      'export default function App(){ return <div><Search/><Bell/></div>; }',
+    ].join('\n')
+    const app = Object.values(parseMultiFileOutput(raw))[0]
+    expect(/from ['"]lucide-react['"]/.test(app)).toBe(true)
+    expect(strictParses(app)).toBe(true)
+  })
+})

--- a/lib/multi-file-parser.ts
+++ b/lib/multi-file-parser.ts
@@ -141,6 +141,29 @@ const AIKIT_COMPONENTS = [
  * Auto-inject missing imports for recharts, lucide-react, and AIKit.
  * Also fixes @/ import aliases to relative paths for Sandpack.
  */
+/**
+ * Collect every identifier already bound by an existing import in the code
+ * (default, named, and aliased). Used to ensure auto-injection never adds a
+ * name that's already imported from another module — which would produce
+ * "Identifier 'X' has already been declared" in Sandpack (builder#64).
+ */
+function collectImportedNames(code: string): Set<string> {
+  const names = new Set<string>()
+  const importRe = /import\s+(?:([A-Za-z_$][\w$]*)\s*,?\s*)?(?:\{([^}]*)\})?\s*from\s*['"][^'"]+['"]/g
+  let m: RegExpExecArray | null
+  while ((m = importRe.exec(code)) !== null) {
+    if (m[1]) names.add(m[1].trim())
+    if (m[2]) {
+      for (const spec of m[2].split(',')) {
+        const s = spec.trim()
+        if (!s) continue
+        names.add(s.split(/\s+as\s+/i).pop()!.trim())
+      }
+    }
+  }
+  return names
+}
+
 function injectMissingImports(code: string): string {
   // Fix @/components/ alias to relative paths (Sandpack doesn't support aliases)
   code = code.replace(/from ['"]@\/components\//g, "from './components/")
@@ -151,30 +174,40 @@ function injectMissingImports(code: string): string {
 
   const imports: string[] = []
 
+  // Names already imported anywhere in the file — never re-inject these, even
+  // from a different module (e.g. LineChart/BarChart/PieChart exist in BOTH
+  // lucide-react and recharts). Re-injecting caused duplicate-declaration
+  // crashes in Sandpack (builder#64).
+  const alreadyImported = collectImportedNames(code)
+
   // Check for AIKit component usage — skip any already imported individually
   const usedAikit = AIKIT_COMPONENTS.filter(c =>
-    new RegExp(`<${c}[\\s/>]`).test(code) &&
-    !new RegExp(`import\\s+.*\\b${c}\\b.*from\\s+`).test(code)
+    new RegExp(`<${c}[\\s/>]`).test(code) && !alreadyImported.has(c)
   )
   if (usedAikit.length > 0) {
     imports.push(`import { ${usedAikit.join(', ')} } from './components/aikit'`)
+    usedAikit.forEach(c => alreadyImported.add(c))
   }
 
   // Check for recharts usage
   const usedRecharts = RECHARTS_COMPONENTS.filter(c =>
-    new RegExp(`<${c}[\\s/>]`).test(code) && !code.includes(`from 'recharts'`) && !code.includes(`from "recharts"`)
+    new RegExp(`<${c}[\\s/>]`).test(code) &&
+    !code.includes(`from 'recharts'`) && !code.includes(`from "recharts"`) &&
+    !alreadyImported.has(c)
   )
   if (usedRecharts.length > 0) {
     imports.push(`import { ${usedRecharts.join(', ')} } from 'recharts'`)
+    usedRecharts.forEach(c => alreadyImported.add(c))
   }
 
   // Check for lucide-react usage
   if (!code.includes(`from 'lucide-react'`) && !code.includes(`from "lucide-react"`)) {
     const usedIcons = LUCIDE_ICONS.filter(icon =>
-      new RegExp(`<${icon}[\\s/>]`).test(code)
+      new RegExp(`<${icon}[\\s/>]`).test(code) && !alreadyImported.has(icon)
     )
     if (usedIcons.length > 0) {
       imports.push(`import { ${usedIcons.join(', ')} } from 'lucide-react'`)
+      usedIcons.forEach(c => alreadyImported.add(c))
     }
   }
 


### PR DESCRIPTION
## Root cause (the real one)
Prior #64 PRs (#65 de-dupe, #66 ternary) were correct but the live 5-run regression still showed `Identifier 'LineChart' has already been declared`. Tracing it: **our own `injectMissingImports` (multi-file-parser) runs AFTER validation and re-introduced the duplicate.**

`LineChart`, `BarChart`, `PieChart` exist in **both** `lucide-react` and `recharts`. When the model imported them from recharts, the injector added them again from lucide-react → duplicate declaration → Sandpack crash → "Something went wrong" preview. The validator's de-dupe couldn't help because the duplicate was created *downstream* of it.

## Fix (`lib/multi-file-parser.ts`)
- `collectImportedNames()` parses every already-bound import (default / named / aliased).
- All three injection lists (aikit, recharts, lucide) are filtered against it — and against names injected earlier in the same pass — so a name is never imported from two modules.

## Tests (3, all strict-parse clean)
- recharts `LineChart` no longer re-injected from lucide
- already-imported AIKit component not duplicated
- genuinely-missing icons still injected

Combined with #65 (de-dupe) and #66 (ternary), this closes the invalid-codegen classes surfaced by live E2E.

Refs #64