### PR TITLE
fix(codegen): reject Sandpack-fatal 'unexpected token' so broken code retries (#64)

### DIFF
--- a/__tests__/lib/code-validator-duplicates.test.ts
+++ b/__tests__/lib/code-validator-duplicates.test.ts
@@ -137,6 +137,7 @@ describe('code-validator: malformed ternary handling (#64 follow-up)', () => {
     'stray ; before the ternary colon': "export default function App(){ const v = c ? 'a'\n : 'b';\n return <div className={v}/>; }",
     'stray ; after the true branch': "export default function App(){ const v =\n c ? 'x';\n : '';\n return <div className={v}/>; }",
     'stray ; before the question mark': "export default function App(){ const v = c;\n ? 'a'\n : 'b';\n return <div className={v}/>; }",
+    'stray ; after arrow open paren': "export default function App(){ const f = (t) => (;\n <div>{t}</div>\n );\n return <div/>; }",
   }
 
   for (const [name, code] of Object.entries(badCases)) {
@@ -156,4 +157,27 @@ describe('code-validator: malformed ternary handling (#64 follow-up)', () => {
     const code = "export default function App(){ return (<div><p>Hello & welcome</p></div>); }"
     expect(validateJavaScriptCode(code).valid).toBe(true)
   })
+})
+
+/**
+ * Guard: rejecting "unexpected token" (so Sandpack-fatal code retries) must NOT
+ * regress valid modern React/TS/JSX. These all pass strict parse and must stay
+ * valid — this is the safety net for the broadened rejection (#64).
+ */
+describe('code-validator: no false positives on valid code (#64 guard)', () => {
+  const valid: Record<string, string> = {
+    fragment: 'export default function App(){ return <><h1>A</h1><p>B</p></>; }',
+    'nested ternary chain': 'export default function App(){ const x=a?b:c?d:e; return <div>{x}</div>; }',
+    'typescript generics': 'export default function App(){ const [s]=React.useState<string[]>([]); return <div>{s.length}</div>; }',
+    'map arrow returning jsx': "export default function App(){ const items=[1,2]; return <ul>{items.map((i)=>(<li key={i}>{i}</li>))}</ul>; }",
+    'template literal className': "export default function App(){ const a='x'; return <div className={`b ${a}`}/>; }",
+    'optional chaining': 'export default function App(){ const o={a:{b:1}}; return <div>{o?.a?.b}</div>; }',
+    'spread props': 'export default function App(){ const p={id:1}; return <div {...p}/>; }',
+    'multiline import': "import {\n useState,\n useEffect\n} from 'react'\nexport default function App(){ const [n]=useState(0); useEffect(()=>{},[]); return <div>{n}</div>; }",
+  }
+  for (const [name, code] of Object.entries(valid)) {
+    it(`valid: ${name}`, () => {
+      expect(validateJavaScriptCode(code).valid, `${name} was wrongly rejected`).toBe(true)
+    })
+  }
 })

--- a/lib/code-validator.ts
+++ b/lib/code-validator.ts
@@ -441,12 +441,14 @@ export function validateJavaScriptCode(code: string): ValidationResult {
       const strictMsg =
         strictError instanceof Error ? strictError.message.replace(/\(\d+:\d+\)/, '').trim() : ''
       const s = strictMsg.toLowerCase()
-      // Sandpack-fatal token errors: a ternary/expression expecting ':' or a
-      // definite "unexpected token, expected X" mismatch. Exclude the benign
-      // "missing semicolon" recovery hint (Sandpack tolerates that).
+      // The errorRecovery parse already passed, so the code is *mostly* well
+      // formed. If the STRICT parse now trips on an "unexpected token", that is
+      // a hard error Sandpack (which parses strictly) will also throw — e.g. a
+      // stray `;` splitting a ternary or after `=> (`. Reject so the retry path
+      // re-generates. "missing semicolon" is a benign recovery hint Sandpack
+      // tolerates, so it's explicitly excluded (builder#64).
       const isSandpackFatal =
-        (s.includes('expected ":"') || s.includes("expected ':'")) ||
-        (s.includes('unexpected token, expected') && !s.includes('missing semicolon'))
+        s.includes('unexpected token') && !s.includes('missing semicolon')
       if (isSandpackFatal) {
         console.error('❌ Code validation failed (strict parse — Sandpack-fatal):', strictMsg)
         return {
@@ -477,16 +479,19 @@ export function validateJavaScriptCode(code: string): ValidationResult {
     // Check if it's a CATASTROPHIC error that will definitely break in browser
     const errorLower = errorMessage.toLowerCase()
 
-    // CRITICAL: Only reject errors that DEFINITELY break in browser
-    // "Unterminated JSX contents" and "unexpected token" are often recoverable
-    // by browser Babel with errorRecovery mode, so we let them through as warnings
+    // The runtime is Sandpack (@babel/standalone, strict) — not the old lenient
+    // browser-Babel path — so a hard parse error here WILL break the preview.
+    // Reject the definite-fatal families so the caller's retry re-generates and
+    // RLHF logs validation_error instead of a false 'success' (builder#64).
     const isCatastrophicError =
       errorLower.includes('unexpected end of file') ||
       errorLower.includes('unexpected eof') ||
       errorLower.includes('unterminated string') ||
-      errorLower.includes('unterminated template')
-      // Removed: 'unterminated jsx contents' — browser Babel handles this
-      // Removed: 'unexpected token' — browser Babel handles this
+      errorLower.includes('unterminated template') ||
+      // "unexpected token" from a full parse failure is Sandpack-fatal (stray
+      // `;` in a ternary, `=> (;`, etc.). The benign "missing semicolon"
+      // recovery hint is a different message and is not matched here.
+      errorLower.includes('unexpected token')
 
     if (isCatastrophicError) {
       // This will definitely fail in browser - report error


### PR DESCRIPTION
## Problem
The 5-run live regression (after #65/#66/#67) still showed 2 shapes rendering "Something went wrong":
- stray `;` splitting a ternary: `buttonVariant === 'solid';` then `? '...' : '...'`
- stray `;` after an arrow's open paren: `const f = (t) => (;`

**Why they slipped through:** Babel's `errorRecovery` parse *threw* on these (recovery has limits), landing in the outer catch where `unexpected token` was explicitly allowed through as valid — a stale carve-out from the old lenient browser-Babel preview path.

## Fix
The runtime is now **Sandpack (@babel/standalone, strict)** — a hard parse failure breaks the preview. Reject the `unexpected token` family (alongside the existing unterminated/EOF families) so the existing retry + agent-fallback re-generates and RLHF logs `validation_error` instead of a false `success`.

## No false positives (proven)
8 valid modern patterns still validate: fragments, nested ternary chains, TS generics, JSX `.map`, template-literal classNames, optional chaining, spread props, multiline imports. These pass strict parse, so they're unaffected.

## Tests: 22 total, all green
Includes the arrow-`=> (;` shape + a dedicated no-false-positive guard block.

Closes #64 (final of 4: #65 de-dupe, #66 ternary autofix, #67 injector, this = strict rejection net)