### PR TITLE
fix(codegen): generalize stray-semicolon-after-open-paren repair (#64)

### DIFF
--- a/__tests__/lib/code-validator-duplicates.test.ts
+++ b/__tests__/lib/code-validator-duplicates.test.ts
@@ -138,6 +138,9 @@ describe('code-validator: malformed ternary handling (#64 follow-up)', () => {
     'stray ; after the true branch': "export default function App(){ const v =\n c ? 'x';\n : '';\n return <div className={v}/>; }",
     'stray ; before the question mark': "export default function App(){ const v = c;\n ? 'a'\n : 'b';\n return <div className={v}/>; }",
     'stray ; after arrow open paren': "export default function App(){ const f = (t) => (;\n <div>{t}</div>\n );\n return <div/>; }",
+    'stray ; after useState(': "export default function App(){ const [x,setX] = useState(;\n {a:1}\n ); return <div>{x.a}</div>; }",
+    'stray ; after reduce(': "export default function App(){ const t = [1,2].reduce(;\n (s,n)=>s+n, 0\n ); return <div>{t}</div>; }",
+    'stray ; after return(': "export default function App(){ return (;\n <div>hi</div>\n ); }",
   }
 
   for (const [name, code] of Object.entries(badCases)) {
@@ -174,6 +177,9 @@ describe('code-validator: no false positives on valid code (#64 guard)', () => {
     'optional chaining': 'export default function App(){ const o={a:{b:1}}; return <div>{o?.a?.b}</div>; }',
     'spread props': 'export default function App(){ const p={id:1}; return <div {...p}/>; }',
     'multiline import': "import {\n useState,\n useEffect\n} from 'react'\nexport default function App(){ const [n]=useState(0); useEffect(()=>{},[]); return <div>{n}</div>; }",
+    'for loop with semicolons': 'export default function App(){ let s=0; for(let i=0;i<3;i++){ s+=i } return <div>{s}</div>; }',
+    'empty call ()': 'export default function App(){ const f=()=>1; return <div>{f()}</div>; }',
+    'normal multiline call': 'export default function App(){ const t=[1,2].reduce(\n (s,n)=>s+n, 0\n ); return <div>{t}</div>; }',
   }
   for (const [name, code] of Object.entries(valid)) {
     it(`valid: ${name}`, () => {

--- a/lib/code-validator.ts
+++ b/lib/code-validator.ts
@@ -327,21 +327,17 @@ function autoFixCode(code: string): { code: string; fixes: string[] } {
     })
   }
 
-  // Fix ARROW OPEN-PAREN (run LAST so nothing re-inserts the semicolon): `=> (;`
-  // — the model puts a stray `;` right after the opening paren of an arrow body
-  // returning JSX, e.g. `const f = (x) => (;`. Babel errorRecovery throws →
-  // Sandpack shows "Unexpected token" (builder#64).
-  const beforeArrowParenFix = fixedCode
-  fixedCode = fixedCode.replace(/=>(\s*)\((\s*);/g, '=>$1($2')
-  if (fixedCode !== beforeArrowParenFix) {
-    fixes.push('Removed stray semicolon after arrow open paren (=> (;)')
-  }
-
-  // Fix RETURN OPEN-PAREN: `return (;` — same defect on an explicit return.
-  const beforeReturnParenFix = fixedCode
-  fixedCode = fixedCode.replace(/return(\s*)\((\s*);/g, 'return$1($2')
-  if (fixedCode !== beforeReturnParenFix) {
-    fixes.push('Removed stray semicolon after return open paren (return (;)')
+  // Fix OPEN-PAREN SEMICOLON (run LAST so nothing re-inserts it): the model
+  // emits a stray `;` immediately after an opening `(` with the real content on
+  // the following line(s) — e.g. `=> (;`, `return (;`, `useState(;`,
+  // `.reduce(;`. Babel errorRecovery throws → Sandpack "Unexpected token"
+  // (builder#64). We only match `(` + optional inline spaces + `;` + a NEWLINE,
+  // which a `for(;;)` / `for(;` loop never produces (its `;` is followed by the
+  // loop condition on the same line, not a newline), so loops stay intact.
+  const beforeOpenParenSemi = fixedCode
+  fixedCode = fixedCode.replace(/\(([ \t]*);([ \t]*\r?\n)/g, '($1$2')
+  if (fixedCode !== beforeOpenParenSemi) {
+    fixes.push('Removed stray semicolon after open paren ((;)')
   }
 
   return { code: fixedCode, fixes }


### PR DESCRIPTION
## Problem
The regression kept surfacing the **same defect on new call sites**: the model emits `(;` right after an opening paren with the real args on the next line — `useState(;`, `.reduce(;`, `=> (;`, `return (;`. My earlier fixes only covered `=>` and `return`, so `useState(;` / `.reduce(;` still crashed Sandpack with "Unexpected token".

## Fix
Replace the two specific fixes with one general rule: `(` + inline spaces + `;` + **NEWLINE** → `(`.

Safe because the newline requirement excludes `for(;;)` / `for(;` loops (their `;` is followed by the loop condition on the same line), empty calls `()`, and normal multiline calls (no stray `;`).

## Tests: 34 total, all green
- 3 new bad cases: `useState(;`, `.reduce(;`, `return(;`
- 3 new safety guards: for-loop, empty call, normal multiline call — all stay valid/untouched

Refs #64