### PR TITLE
fix(codegen): resolve Re-recharts aliases + merge missing lucide icons (#64)

### DIFF
--- a/__tests__/lib/multi-file-import-injection.test.ts
+++ b/__tests__/lib/multi-file-import-injection.test.ts
@@ -98,4 +98,40 @@ describe('multi-file import injection: no cross-module duplicates (#64)', () => 
     expect(strictParses(app)).toBe(true)
     expect(app).toMatch(/import React, \{ useState \} from 'react'/)
   })
+
+  // The prompt tells the model to use "Re"-prefixed recharts aliases and to
+  // treat lucide icons as globally available — the injector must resolve both
+  // or they render as "X is not defined" (builder#64 — found in live E2E).
+  it('imports a "Re"-prefixed recharts alias (ReLineChart) with an as-alias', () => {
+    const raw = [
+      "import React from 'react'",
+      "import { ResponsiveContainer, Line } from 'recharts'",
+      'export default function App(){ return <ResponsiveContainer><ReLineChart data={[]}><Line/></ReLineChart></ResponsiveContainer>; }',
+    ].join('\n')
+    const app = Object.values(parseMultiFileOutput(raw))[0]
+    expect(/LineChart as ReLineChart/.test(app)).toBe(true)
+    expect(strictParses(app)).toBe(true)
+  })
+
+  it('merges a used-but-unimported lucide icon into the imports', () => {
+    const raw = [
+      "import React from 'react'",
+      "import { Search, Bell } from 'lucide-react'",
+      'export default function App(){ return <div><Search/><Bell/><Check/></div>; }',
+    ].join('\n')
+    const app = Object.values(parseMultiFileOutput(raw))[0]
+    expect(/import\s*\{[^}]*\bCheck\b[^}]*\}\s*from\s*['"]lucide-react['"]/.test(app)).toBe(true)
+    expect(strictParses(app)).toBe(true)
+  })
+
+  it('does not duplicate an already-imported recharts real name', () => {
+    const raw = [
+      "import React from 'react'",
+      "import { LineChart, Line } from 'recharts'",
+      'export default function App(){ return <LineChart><Line/></LineChart>; }',
+    ].join('\n')
+    const app = Object.values(parseMultiFileOutput(raw))[0]
+    expect(strictParses(app)).toBe(true)
+    expect((app.match(/import[^\n]*\bLineChart\b/g) || []).length).toBe(1)
+  })
 })

--- a/lib/multi-file-parser.ts
+++ b/lib/multi-file-parser.ts
@@ -113,6 +113,22 @@ const RECHARTS_COMPONENTS = [
   'PolarAngleAxis', 'PolarRadiusAxis',
 ]
 
+/**
+ * The system prompt tells the model to use "Re"-prefixed recharts aliases
+ * (ReLineChart, ReBarChart, RePieChart) and RechartsTooltip to avoid colliding
+ * with lucide's LineChart/BarChart/PieChart. The injector must map those JSX
+ * names back to real recharts exports via `as` aliases, or they render as
+ * "ReLineChart is not defined" (builder#64). Key = JSX name used, value = real
+ * recharts export.
+ */
+const RECHARTS_ALIASES: Record<string, string> = {
+  ReLineChart: 'LineChart',
+  ReBarChart: 'BarChart',
+  RePieChart: 'PieChart',
+  ReAreaChart: 'AreaChart',
+  RechartsTooltip: 'Tooltip',
+}
+
 /** Lucide icon names commonly used in generated code */
 const LUCIDE_ICONS = [
   'Search', 'Menu', 'X', 'ChevronDown', 'ChevronRight', 'ChevronLeft', 'ChevronUp',
@@ -193,26 +209,38 @@ function injectMissingImports(code: string): string {
     usedAikit.forEach(c => alreadyImported.add(c))
   }
 
-  // Check for recharts usage
-  const usedRecharts = RECHARTS_COMPONENTS.filter(c =>
-    new RegExp(`<${c}[\\s/>]`).test(code) &&
-    !code.includes(`from 'recharts'`) && !code.includes(`from "recharts"`) &&
-    !alreadyImported.has(c)
-  )
-  if (usedRecharts.length > 0) {
-    imports.push(`import { ${usedRecharts.join(', ')} } from 'recharts'`)
-    usedRecharts.forEach(c => alreadyImported.add(c))
+  // Check for recharts usage — real names AND the "Re"-prefixed aliases the
+  // prompt instructs the model to use (ReLineChart → LineChart as ReLineChart).
+  // Merge missing names as a separate `from 'recharts'` import even if one
+  // already exists (ESM allows it; alreadyImported prevents name collisions),
+  // so a used-but-unimported chart part no longer renders "X is not defined".
+  const rechartsSpecs: string[] = []
+  for (const real of RECHARTS_COMPONENTS) {
+    if (new RegExp(`<${real}[\\s/>]`).test(code) && !alreadyImported.has(real)) {
+      rechartsSpecs.push(real)
+      alreadyImported.add(real)
+    }
+  }
+  for (const [alias, real] of Object.entries(RECHARTS_ALIASES)) {
+    if (new RegExp(`<${alias}[\\s/>]`).test(code) && !alreadyImported.has(alias)) {
+      rechartsSpecs.push(`${real} as ${alias}`)
+      alreadyImported.add(alias)
+    }
+  }
+  if (rechartsSpecs.length > 0) {
+    imports.push(`import { ${rechartsSpecs.join(', ')} } from 'recharts'`)
   }
 
-  // Check for lucide-react usage
-  if (!code.includes(`from 'lucide-react'`) && !code.includes(`from "lucide-react"`)) {
-    const usedIcons = LUCIDE_ICONS.filter(icon =>
-      new RegExp(`<${icon}[\\s/>]`).test(code) && !alreadyImported.has(icon)
-    )
-    if (usedIcons.length > 0) {
-      imports.push(`import { ${usedIcons.join(', ')} } from 'lucide-react'`)
-      usedIcons.forEach(c => alreadyImported.add(c))
-    }
+  // Check for lucide-react usage — merge any missing icons even when a
+  // lucide-react import already exists (the model often imports some icons but
+  // uses more), so a used-but-unimported icon no longer renders "X is not
+  // defined" (builder#64).
+  const usedIcons = LUCIDE_ICONS.filter(icon =>
+    new RegExp(`<${icon}[\\s/>]`).test(code) && !alreadyImported.has(icon)
+  )
+  if (usedIcons.length > 0) {
+    imports.push(`import { ${usedIcons.join(', ')} } from 'lucide-react'`)
+    usedIcons.forEach(c => alreadyImported.add(c))
   }
 
   if (imports.length === 0) return code


### PR DESCRIPTION
## Problem
With the syntax-error classes fixed (#65–#71), the regression surfaced the **runtime** class: `ReLineChart is not defined` and `Check is not defined`.

- **`ReLineChart`**: the system prompt instructs the model to use `Re`-prefixed recharts aliases (ReLineChart/ReBarChart/RePieChart/RechartsTooltip) to avoid colliding with lucide's `LineChart` — but the import injector only knew the *real* recharts names, so the alias was never imported.
- **`Check`**: the injector skipped lucide injection entirely when *any* lucide import already existed, so an icon the model used but didn't import stayed undefined.

## Fix (`lib/multi-file-parser.ts`)
- `RECHARTS_ALIASES` map → inject `import { LineChart as ReLineChart } from 'recharts'` for used aliases.
- lucide: merge missing icons via an additional import even when a lucide import already exists (name collisions still prevented by the `alreadyImported` guard from #67).

## Tests: 9 injection tests
alias resolution, icon merge, no-duplicate guards — all strict-parse clean.

Refs #64 (the runtime not-defined class, distinct from the syntax-error classes)