### PR TITLE
fix(codegen): close unterminated block comments correctly (#64)

### DIFF
--- a/__tests__/lib/code-validator-duplicates.test.ts
+++ b/__tests__/lib/code-validator-duplicates.test.ts
@@ -141,6 +141,7 @@ describe('code-validator: malformed ternary handling (#64 follow-up)', () => {
     'stray ; after useState(': "export default function App(){ const [x,setX] = useState(;\n {a:1}\n ); return <div>{x.a}</div>; }",
     'stray ; after reduce(': "export default function App(){ const t = [1,2].reduce(;\n (s,n)=>s+n, 0\n ); return <div>{t}</div>; }",
     'stray ; after return(': "export default function App(){ return (;\n <div>hi</div>\n ); }",
+    'unterminated trailing block comment': 'export default function App(){ return <div>hi</div>; }\n/* -----\n  NOTE: components are global\n  no imports needed',
   }
 
   for (const [name, code] of Object.entries(badCases)) {

--- a/e2e/codegen-no-syntax-errors.spec.ts
+++ b/e2e/codegen-no-syntax-errors.spec.ts
@@ -15,6 +15,7 @@ const PROMPTS = [
   'Build a settings panel using Card, CardHeader, CardTitle and CardContent with form fields.',
   'Build a product page with a Button that has outline and solid variants using conditional className styling.',
   'Build a user profile dashboard with Card components, tabs, and a variant-styled Button group.',
+  'Build a revenue analytics dashboard with recharts line and bar charts, MetricCards, and lucide icons throughout.',
 ]
 
 test.describe('codegen produces renderable output (#64)', () => {

--- a/lib/code-validator.ts
+++ b/lib/code-validator.ts
@@ -25,12 +25,19 @@ function autoFixCode(code: string): { code: string; fixes: string[] } {
   let fixedCode = code
   const fixes: string[] = []
 
-  // Fix TRUNCATION: Close unterminated JSX comments from LLM truncation
+  // Fix TRUNCATION: Close unterminated block comments. The model sometimes
+  // emits `/* ... ` with no closing `*/` (often a trailing NOTE banner). Append
+  // just `*/` — appending `*/}` (the old behavior) left a stray `}` that itself
+  // broke the parse when the comment wasn't inside JSX braces (builder#64).
   const openComments = (fixedCode.match(/\/\*/g) || []).length
   const closeComments = (fixedCode.match(/\*\//g) || []).length
   if (openComments > closeComments) {
-    fixedCode += ' */}'
-    fixes.push('Closed unterminated JSX comment from truncation')
+    // Was the still-open `/*` opened inside a JSX expression (`{/* ... `)?
+    const lastOpen = fixedCode.lastIndexOf('/*')
+    const between = fixedCode.slice(Math.max(0, lastOpen - 40), lastOpen)
+    const insideJsxBraces = /\{\s*$/.test(between)
+    fixedCode += insideJsxBraces ? ' */}' : ' */'
+    fixes.push('Closed unterminated block comment from truncation')
   }
 
   // Fix TRUNCATION: Close unterminated strings and template literals


### PR DESCRIPTION
## Problem
Regression surfaced `Unterminated comment (280:0)` — the model emits a trailing `/* NOTE: All Shadcn UI components... ` banner with no closing `*/`. The existing truncation fix appended `*/}`, which closed the comment but left a **stray `}`** → `Unexpected token` when the comment wasn't inside JSX braces.

## Fix
Append just `*/` (or `*/}` only when the open `/*` was inside a JSX expression `{/* ... `). Trailing NOTE-banner comments now auto-fix to valid; normal/complete comments untouched. Also widens the e2e regression to a 6th chart-heavy prompt.

37 validator tests, all green.

Refs #64