### PR TITLE
feat(agent): AGENT_RUNTIME switch — swap headless agent from claude to cody-cli (#79)

### DIFF
--- a/__tests__/lib/agent-runtime.test.ts
+++ b/__tests__/lib/agent-runtime.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest'
+import {
+  getAgentRuntime,
+  getAgentBinary,
+  getAgentSpawnEnv,
+  isAgentEnabled,
+  isAgentFallbackEnabled,
+} from '@/lib/agent/agent-runtime'
+
+const env = (o: Record<string, string | undefined>) => o as NodeJS.ProcessEnv
+
+describe('agent-runtime (#79)', () => {
+  describe('getAgentRuntime', () => {
+    it('defaults to claude', () => {
+      expect(getAgentRuntime(env({}))).toBe('claude')
+    })
+    it('returns cody when AGENT_RUNTIME=cody (case-insensitive, trimmed)', () => {
+      expect(getAgentRuntime(env({ AGENT_RUNTIME: 'cody' }))).toBe('cody')
+      expect(getAgentRuntime(env({ AGENT_RUNTIME: '  CODY ' }))).toBe('cody')
+    })
+    it('returns claude for any other value', () => {
+      expect(getAgentRuntime(env({ AGENT_RUNTIME: 'gpt' }))).toBe('claude')
+    })
+  })
+
+  describe('getAgentBinary', () => {
+    it('maps runtime to binary name', () => {
+      expect(getAgentBinary(env({ AGENT_RUNTIME: 'cody' }))).toBe('cody')
+      expect(getAgentBinary(env({}))).toBe('claude')
+    })
+  })
+
+  describe('getAgentSpawnEnv', () => {
+    it('returns no overrides for claude', () => {
+      expect(getAgentSpawnEnv(env({}))).toEqual({})
+    })
+    it('points cody at AINative and passes the key through', () => {
+      const out = getAgentSpawnEnv(env({ AGENT_RUNTIME: 'cody', AINATIVE_API_KEY: 'k-123' }))
+      expect(out.ANTHROPIC_BASE_URL).toBe('https://api.ainative.studio')
+      expect(out.ANTHROPIC_API_KEY).toBe('k-123')
+    })
+    it('honors AINATIVE_API_URL / CODY_BASE_URL override for cody', () => {
+      expect(
+        getAgentSpawnEnv(env({ AGENT_RUNTIME: 'cody', AINATIVE_API_URL: 'https://core.local' }))
+          .ANTHROPIC_BASE_URL,
+      ).toBe('https://core.local')
+    })
+    it('falls back through key sources', () => {
+      expect(
+        getAgentSpawnEnv(env({ AGENT_RUNTIME: 'cody', ZERODB_API_KEY: 'z' })).ANTHROPIC_API_KEY,
+      ).toBe('z')
+    })
+    it('omits the key when none is set', () => {
+      const out = getAgentSpawnEnv(env({ AGENT_RUNTIME: 'cody' }))
+      expect(out.ANTHROPIC_API_KEY).toBeUndefined()
+    })
+  })
+
+  describe('isAgentEnabled', () => {
+    it('true when USE_CLAUDE_AGENT=true', () => {
+      expect(isAgentEnabled(env({ USE_CLAUDE_AGENT: 'true' }))).toBe(true)
+    })
+    it('true for cody runtime by default', () => {
+      expect(isAgentEnabled(env({ AGENT_RUNTIME: 'cody' }))).toBe(true)
+    })
+    it('false for cody when USE_CODY_AGENT=false', () => {
+      expect(isAgentEnabled(env({ AGENT_RUNTIME: 'cody', USE_CODY_AGENT: 'false' }))).toBe(false)
+    })
+    it('false by default (claude runtime, no flag)', () => {
+      expect(isAgentEnabled(env({}))).toBe(false)
+    })
+  })
+
+  describe('isAgentFallbackEnabled', () => {
+    it('true when USE_CLAUDE_AGENT_FALLBACK=true', () => {
+      expect(isAgentFallbackEnabled(env({ USE_CLAUDE_AGENT_FALLBACK: 'true' }))).toBe(true)
+    })
+    it('true when the agent is enabled', () => {
+      expect(isAgentFallbackEnabled(env({ AGENT_RUNTIME: 'cody' }))).toBe(true)
+    })
+    it('false by default', () => {
+      expect(isAgentFallbackEnabled(env({}))).toBe(false)
+    })
+  })
+})

--- a/lib/agent/agent-runtime.ts
+++ b/lib/agent/agent-runtime.ts
@@ -1,0 +1,66 @@
+/**
+ * Agent runtime selection (builder#79).
+ *
+ * The headless agent spawns a Claude-Code-compatible CLI with
+ * `--output-format stream-json`. Two runtimes speak that protocol:
+ *   - `claude`  — Anthropic's Claude Code binary (external dependency)
+ *   - `cody`    — @ainative/cody-cli, AINative's own harness (defaults to
+ *                 api.ainative.studio, no external Anthropic dependency)
+ *
+ * `AGENT_RUNTIME=cody|claude` selects the binary. Default is `claude` for
+ * backward compatibility; set `AGENT_RUNTIME=cody` to use the AINative harness.
+ */
+
+export type AgentRuntime = 'cody' | 'claude'
+
+/** Resolve the configured agent runtime from the environment. */
+export function getAgentRuntime(env: NodeJS.ProcessEnv = process.env): AgentRuntime {
+  const raw = (env.AGENT_RUNTIME || '').trim().toLowerCase()
+  return raw === 'cody' ? 'cody' : 'claude'
+}
+
+/** The binary name to spawn for the configured runtime. */
+export function getAgentBinary(env: NodeJS.ProcessEnv = process.env): string {
+  return getAgentRuntime(env) === 'cody' ? 'cody' : 'claude'
+}
+
+/**
+ * The environment overrides to pass to the spawned agent. For cody we ensure it
+ * points at AINative inference (it already defaults there, but we make it
+ * explicit and pass the AINative key through as the ANTHROPIC_API_KEY the
+ * Claude-compatible CLI expects).
+ */
+export function getAgentSpawnEnv(env: NodeJS.ProcessEnv = process.env): Record<string, string> {
+  const runtime = getAgentRuntime(env)
+  const overrides: Record<string, string> = {}
+  if (runtime === 'cody') {
+    // cody-cli defaults to https://api.ainative.studio; make it explicit so the
+    // builder's ANTHROPIC_BASE_URL (if set for Claude) doesn't leak into cody.
+    overrides.ANTHROPIC_BASE_URL =
+      env.AINATIVE_API_URL || env.CODY_BASE_URL || 'https://api.ainative.studio'
+    const key = env.AINATIVE_API_KEY || env.ANTHROPIC_API_KEY || env.ZERODB_API_KEY
+    if (key) overrides.ANTHROPIC_API_KEY = key
+  }
+  return overrides
+}
+
+/**
+ * Whether the headless agent path is enabled at all. Enabled when either an
+ * explicit flag is set (`USE_CLAUDE_AGENT`), or the runtime is `cody` (the
+ * AINative harness is safe to use by default since it has no external cost/
+ * dependency risk).
+ */
+export function isAgentEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  if (env.USE_CLAUDE_AGENT === 'true') return true
+  if (getAgentRuntime(env) === 'cody' && env.USE_CODY_AGENT !== 'false') return true
+  return false
+}
+
+/**
+ * Whether the agent may be used as a fallback when the fast path fails. Enabled
+ * by `USE_CLAUDE_AGENT_FALLBACK`, `USE_CLAUDE_AGENT`, or the cody runtime.
+ */
+export function isAgentFallbackEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  if (env.USE_CLAUDE_AGENT_FALLBACK === 'true') return true
+  return isAgentEnabled(env)
+}

--- a/lib/agent/claude-agent.ts
+++ b/lib/agent/claude-agent.ts
@@ -15,6 +15,13 @@
 
 import { spawn, type ChildProcess } from 'child_process'
 import { createWorktree, getWorktreeFiles, getWorktreePath } from './worktree-manager'
+import {
+  getAgentBinary,
+  getAgentRuntime,
+  getAgentSpawnEnv,
+  isAgentEnabled,
+  isAgentFallbackEnabled,
+} from './agent-runtime'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -125,18 +132,17 @@ RULES:
  * Returns true if the headless Claude agent is enabled.
  */
 export function isClaudeAgentEnabled(): boolean {
-  return process.env.USE_CLAUDE_AGENT === 'true'
+  // Delegates to the runtime resolver — true for USE_CLAUDE_AGENT=true or the
+  // cody runtime (#79).
+  return isAgentEnabled()
 }
 
 /**
- * Returns true if the Claude agent fallback (for validation failures) is enabled.
- * Enabled when either USE_CLAUDE_AGENT_FALLBACK=true or USE_CLAUDE_AGENT=true.
+ * Returns true if the agent fallback (for validation failures) is enabled.
+ * Enabled by USE_CLAUDE_AGENT_FALLBACK, USE_CLAUDE_AGENT, or the cody runtime.
  */
 export function isClaudeAgentFallbackEnabled(): boolean {
-  return (
-    process.env.USE_CLAUDE_AGENT_FALLBACK === 'true' ||
-    process.env.USE_CLAUDE_AGENT === 'true'
-  )
+  return isAgentFallbackEnabled()
 }
 
 // ---------------------------------------------------------------------------
@@ -156,10 +162,10 @@ export async function* runHeadlessAgent(
   chatId: string,
   options: AgentOptions = {},
 ): AsyncGenerator<AgentEvent> {
-  if (!isClaudeAgentEnabled()) {
+  if (!isAgentEnabled()) {
     yield {
       type: 'error',
-      error: 'Claude agent is not enabled. Set USE_CLAUDE_AGENT=true.',
+      error: 'Agent runtime is not enabled. Set USE_CLAUDE_AGENT=true or AGENT_RUNTIME=cody.',
       fatal: true,
     }
     return
@@ -209,24 +215,28 @@ export async function* runHeadlessAgent(
   const fullSystemPrompt = AGENT_SYSTEM_PROMPT + (systemPrompt ? '\n\n' + systemPrompt : '')
   args.push('--append-system-prompt', fullSystemPrompt)
 
-  // 3. Spawn the claude process
-  yield { type: 'build_step', step: `Starting Claude agent (model: ${model})` }
+  // 3. Spawn the agent process — binary + env resolved by AGENT_RUNTIME (#79).
+  //    Both `claude` and `cody` speak the same stream-json protocol; `cody`
+  //    (AINative's own harness) points at api.ainative.studio and has no
+  //    external Anthropic dependency.
+  const agentBinary = getAgentBinary()
+  const runtime = getAgentRuntime()
+  yield { type: 'build_step', step: `Starting ${runtime} agent (model: ${model})` }
 
   let child: ChildProcess
   try {
-    child = spawn('claude', args, {
+    child = spawn(agentBinary, args, {
       cwd: worktreePath,
       env: {
         ...process.env,
-        // Ensure the agent uses the project's ANTHROPIC_API_KEY
-        // ANTHROPIC_BASE_URL is respected automatically by the CLI
+        ...getAgentSpawnEnv(),
       },
       stdio: ['ignore', 'pipe', 'pipe'],  // Close stdin immediately (no interactive input)
     })
   } catch (err) {
     yield {
       type: 'error',
-      error: `Failed to spawn claude CLI: ${err instanceof Error ? err.message : String(err)}`,
+      error: `Failed to spawn ${agentBinary} CLI: ${err instanceof Error ? err.message : String(err)}`,
       fatal: true,
     }
     return


### PR DESCRIPTION
## Summary
Phase 0 of the cody-cli integration (`docs/design/CODY_CLI_INTEGRATION.md`). The builder's headless agent spawned the external Anthropic `claude` binary — fragile on Railway. `@ainative/cody-cli` (published `0.12.1`, on PATH) is a drop-in: same stream-json protocol, same CLI flags, defaults to `api.ainative.studio`, no external Anthropic dependency.

## Changes
- `lib/agent/agent-runtime.ts` — resolves binary + spawn env from `AGENT_RUNTIME=cody|claude` (default `claude` for back-compat). For cody: points `ANTHROPIC_BASE_URL` at AINative, threads the AINative key through.
- `lib/agent/claude-agent.ts` — spawns the resolved binary; enablement delegates to the runtime helpers (cody enabled by default via `AGENT_RUNTIME=cody`).

## Verified live
```
cody --print --output-format stream-json --bare --max-turns 1 --model gpt-oss-120b
```
against AINative emitted **exactly** the `system/init` → `assistant` (message.content[].text) → `result` (usage) event shapes the builder's existing parser consumes. Generated valid code, reported token usage. Genuine drop-in — no parser changes needed.

## Testing
- `agent-runtime.ts`: **100% coverage**, 16 tests.
- All 58 existing `claude-agent` tests still pass (90 total).
- `tsc --noEmit` clean.

## Rollout
Set `AGENT_RUNTIME=cody` on Railway to activate. `claude` remains the default and fallback until parity is proven in production.

Closes #79