### PR TITLE
feat(agent): authoritative build→verify repair loop (#80, Phase 1)

### DIFF
--- a/__tests__/lib/verify-loop.test.ts
+++ b/__tests__/lib/verify-loop.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import {
+  VERIFY_AGENT_TOOLS,
+  VERIFY_AGENT_MAX_BUDGET_USD,
+  VERIFY_MAX_TURNS,
+  buildVerifySystemPrompt,
+  buildVerifyPrompt,
+  buildVerifyAgentOptions,
+} from '@/lib/agent/verify-loop'
+
+describe('verify-loop (#80)', () => {
+  it('grants the agent Read + Bash so it can actually verify, plus Write/Edit', () => {
+    expect(VERIFY_AGENT_TOOLS).toContain('Read')
+    expect(VERIFY_AGENT_TOOLS).toContain('Bash')
+    expect(VERIFY_AGENT_TOOLS).toContain('Write')
+    expect(VERIFY_AGENT_TOOLS).toContain('Edit')
+  })
+
+  it('has a sane budget and turn cap', () => {
+    expect(VERIFY_AGENT_MAX_BUDGET_USD).toBeGreaterThan(0)
+    expect(VERIFY_MAX_TURNS).toBeGreaterThanOrEqual(2)
+    expect(VERIFY_MAX_TURNS).toBeLessThanOrEqual(6)
+  })
+
+  it('system prompt instructs verify + covers the runtime error class', () => {
+    const p = buildVerifySystemPrompt()
+    expect(p).toMatch(/verify/i)
+    expect(p).toMatch(/Element type is invalid/i)
+    expect(p).toMatch(/export default function App/)
+    expect(p).toMatch(/```jsx/)
+  })
+
+  it('user prompt includes the error, the broken code, and the original ask', () => {
+    const p = buildVerifyPrompt('build a dashboard', 'Unexpected token', 'const x =;')
+    expect(p).toMatch(/Unexpected token/)
+    expect(p).toMatch(/build a dashboard/)
+    expect(p).toMatch(/const x =;/)
+    expect(p).toMatch(/```jsx/)
+  })
+
+  it('truncates very long broken code', () => {
+    const big = 'x'.repeat(20000)
+    const p = buildVerifyPrompt('p', 'e', big)
+    // 12000 cap + surrounding text — well under the raw 20000
+    expect(p.length).toBeLessThan(13000)
+  })
+
+  it('handles empty/undefined broken code without throwing', () => {
+    expect(() => buildVerifyPrompt('p', 'e', '')).not.toThrow()
+    // @ts-expect-error exercise the nullish path
+    expect(() => buildVerifyPrompt('p', 'e', undefined)).not.toThrow()
+  })
+
+  it('buildVerifyAgentOptions wires tools/budget/turns/systemPrompt', () => {
+    const opts = buildVerifyAgentOptions('gpt-oss-120b')
+    expect(opts.model).toBe('gpt-oss-120b')
+    expect(opts.allowedTools).toEqual(VERIFY_AGENT_TOOLS)
+    expect(opts.maxBudgetUsd).toBe(VERIFY_AGENT_MAX_BUDGET_USD)
+    expect(opts.maxTurns).toBe(VERIFY_MAX_TURNS)
+    expect(opts.systemPrompt).toMatch(/verify/i)
+  })
+
+  it('buildVerifyAgentOptions works with no model (runtime default)', () => {
+    const opts = buildVerifyAgentOptions()
+    expect(opts.model).toBeUndefined()
+    expect(opts.allowedTools.length).toBeGreaterThan(0)
+  })
+})

--- a/app/api/chat-ws/route.ts
+++ b/app/api/chat-ws/route.ts
@@ -9,6 +9,7 @@ import { updatePreviewPartial, storePreview, getChatData } from '@/lib/preview-s
 import { validateGeneratedCode } from '@/lib/code-validator'
 import { buildValidationFallbackComponent } from '@/lib/validation-fallback'
 import { runValidationRetryLoop, buildRepairPrompt } from '@/lib/generation-retry'
+import { buildVerifyPrompt, buildVerifyAgentOptions } from '@/lib/agent/verify-loop'
 import { stripGradients } from '@/lib/gradient-blocker'
 import { fetchContextualImages, formatImagesForPrompt, getFallbackImages } from '@/lib/services/unsplash.service'
 import { extractComponentCode } from '@/lib/agent/component-generation-tool'
@@ -912,25 +913,18 @@ OUTPUT: Generate 150-300 lines of COMPLETE, working code. Make it visually polis
                 step: 'Running Claude agent to fix syntax errors...'
               })}\n\n`))
 
-              const agentFixPrompt = `Fix this React component that has syntax errors. The error is: ${validation.error}
-
-Here is the broken code:
-\`\`\`jsx
-${finalContent.slice(0, 12000)}
-\`\`\`
-
-Fix it and make sure \`npm run build\` passes.
-Return ONLY the fixed code — no explanations. Wrap the code in \`\`\`jsx markers.
-The component MUST have \`export default function App()\` or \`export default App\`.`
-
+              // Phase 1 (#80): authoritative verify loop — give the agent Read+Bash
+              // so it can genuinely typecheck/build and self-correct runtime errors
+              // (e.g. "Element type is invalid"), not just re-write blindly.
+              const agentFixPrompt = buildVerifyPrompt(message, validation.error || 'unknown', finalContent)
               const agentChatId = `fix-${responseId}-${Date.now()}`
               let agentOutput = ''
 
-              for await (const event of runHeadlessAgent(agentFixPrompt, agentChatId, {
-                model: 'sonnet',
-                maxBudgetUsd: 0.50,
-                systemPrompt: 'You are a React code fixer. Fix syntax errors in the provided component. Output ONLY the corrected code wrapped in ```jsx markers. Do not add explanations.',
-              })) {
+              for await (const event of runHeadlessAgent(
+                agentFixPrompt,
+                agentChatId,
+                buildVerifyAgentOptions(),
+              )) {
                 switch (event.type) {
                   case 'build_step':
                     safeEnqueue(encoder.encode(`data: ${JSON.stringify({

--- a/lib/agent/verify-loop.ts
+++ b/lib/agent/verify-loop.ts
@@ -1,0 +1,73 @@
+/**
+ * Authoritative build→error→retry verification (builder#80, Phase 1).
+ *
+ * The fast path generates code and validates it with a parser; that can't catch
+ * runtime/scope errors (undefined components, bad imports) that only surface when
+ * the code actually runs. When the agent runtime is available (cody-cli) it can
+ * run tools — so we give a repair agent `Read` + `Bash` so it can genuinely
+ * verify (typecheck/build) and self-correct, per the closed-loop pattern from
+ * Cursor/Aider/OpenHands.
+ *
+ * This module holds the pure, testable pieces: the tool set, the budget, and the
+ * verify instruction. The chat-ws route wires them into runHeadlessAgent.
+ */
+
+/** Tools the verify agent needs to genuinely check its work (not just write). */
+export const VERIFY_AGENT_TOOLS = ['Read', 'Write', 'Edit', 'Bash']
+
+/** A slightly higher budget than a blind write, since verification runs tools. */
+export const VERIFY_AGENT_MAX_BUDGET_USD = 0.75
+
+/** Max verify iterations before falling back to graceful degradation. */
+export const VERIFY_MAX_TURNS = 4
+
+/**
+ * Build the system prompt for the verify agent. It must fix the code AND confirm
+ * it actually builds/renders, not just looks right.
+ */
+export function buildVerifySystemPrompt(): string {
+  return (
+    'You are a React build-and-verify agent working in an isolated workspace. ' +
+    'Fix the provided component so it BUILDS and RENDERS cleanly. ' +
+    'After editing, verify your work (typecheck / run the build if available) and ' +
+    'fix any remaining errors — including runtime errors like "Element type is invalid" ' +
+    '(a component used but not defined or imported). ' +
+    'Every component used in JSX MUST be defined in the file, imported, or a known primitive. ' +
+    'The result MUST have `export default function App()`. ' +
+    'Output ONLY the corrected code wrapped in ```jsx markers — no explanations.'
+  )
+}
+
+/**
+ * Build the user prompt for the verify agent given the broken code and the
+ * validation error that triggered repair.
+ */
+export function buildVerifyPrompt(prompt: string, error: string, brokenCode: string): string {
+  return (
+    `Fix this React component. It failed validation with:\n\nERROR: ${error}\n\n` +
+    `BROKEN CODE:\n\`\`\`jsx\n${(brokenCode || '').slice(0, 12000)}\n\`\`\`\n\n` +
+    `Produce a corrected, complete version of: ${prompt}\n` +
+    'Make sure every component resolves and the build passes. Return ONLY the fixed code in ```jsx markers.'
+  )
+}
+
+/**
+ * Options for a verify-agent run — passed straight to runHeadlessAgent so the
+ * agent can Read/Bash to verify. Model is chosen by the caller (defaults left to
+ * the runtime).
+ */
+export function buildVerifyAgentOptions(model?: string): {
+  model?: string
+  maxBudgetUsd: number
+  maxTurns: number
+  allowedTools: string[]
+  systemPrompt: string
+} {
+  return {
+    model,
+    maxBudgetUsd: VERIFY_AGENT_MAX_BUDGET_USD,
+    maxTurns: VERIFY_MAX_TURNS,
+    allowedTools: VERIFY_AGENT_TOOLS,
+    systemPrompt: buildVerifySystemPrompt(),
+  }
+}


### PR DESCRIPTION
## Summary
Phase 1 of cody-cli integration. The fast-path parser can't catch runtime/scope errors (undefined components, bad imports) that only surface at render. With the agent runtime available (#79), the repair agent can run tools — so it now gets `Read + Bash + Write + Edit` and is instructed to **verify** (typecheck/build) and self-correct, per the closed-loop pattern (Cursor/Aider/OpenHands).

## Changes
- `lib/agent/verify-loop.ts` — pure, testable pieces: verify tool set, budget, turn cap, and the verify system + user prompts (the verify prompt explicitly targets the `Element type is invalid` runtime class and enforces `export default function App()`).
- `app/api/chat-ws/route.ts` — repair fallback wires these into `runHeadlessAgent`.

## Testing
- `verify-loop.ts`: **100% coverage**, 8 tests.
- `tsc --noEmit` clean.

Closes #80