### PR TITLE
feat(codegen): checkpoint last-good + degradation ladder (#81, Phase 2)

### DIFF
--- a/__tests__/lib/generation-checkpoint.test.ts
+++ b/__tests__/lib/generation-checkpoint.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import {
+  GenerationCheckpoint,
+  resolveDegradation,
+} from '@/lib/generation-checkpoint'
+
+describe('GenerationCheckpoint (#81)', () => {
+  it('starts empty', () => {
+    const cp = new GenerationCheckpoint()
+    expect(cp.hasValid()).toBe(false)
+    expect(cp.get()).toBeNull()
+  })
+
+  it('records a valid stage', () => {
+    const cp = new GenerationCheckpoint()
+    cp.record('initial', 'const App = () => <div/>', true)
+    expect(cp.hasValid()).toBe(true)
+    expect(cp.get()).toEqual({ code: 'const App = () => <div/>', stage: 'initial' })
+  })
+
+  it('ignores invalid stages', () => {
+    const cp = new GenerationCheckpoint()
+    cp.record('initial', 'broken(;', false)
+    expect(cp.hasValid()).toBe(false)
+  })
+
+  it('ignores empty/whitespace code even if flagged valid', () => {
+    const cp = new GenerationCheckpoint()
+    cp.record('initial', '   ', true)
+    expect(cp.hasValid()).toBe(false)
+  })
+
+  it('the latest valid stage wins', () => {
+    const cp = new GenerationCheckpoint()
+    cp.record('initial', 'v1', true)
+    cp.record('retry', 'v2', true)
+    expect(cp.get()).toEqual({ code: 'v2', stage: 'retry' })
+  })
+
+  it('a later INVALID stage does not clobber an earlier valid checkpoint', () => {
+    const cp = new GenerationCheckpoint()
+    cp.record('initial', 'good', true)
+    cp.record('retry', 'regressed(;', false)
+    expect(cp.get()).toEqual({ code: 'good', stage: 'initial' })
+  })
+})
+
+describe('resolveDegradation (#81)', () => {
+  it('serves current code when it is valid', () => {
+    const cp = new GenerationCheckpoint()
+    const out = resolveDegradation('current code', true, cp)
+    expect(out).toEqual({ kind: 'current', code: 'current code' })
+  })
+
+  it('serves the checkpoint when current is invalid but a valid version exists', () => {
+    const cp = new GenerationCheckpoint()
+    cp.record('initial', 'earlier working', true)
+    const out = resolveDegradation('broken(;', false, cp)
+    expect(out).toEqual({ kind: 'checkpoint', code: 'earlier working', stage: 'initial' })
+  })
+
+  it('falls back when current is invalid and there is no checkpoint', () => {
+    const cp = new GenerationCheckpoint()
+    const out = resolveDegradation('broken(;', false, cp)
+    expect(out).toEqual({ kind: 'fallback' })
+  })
+
+  it('falls back when current is valid-but-empty and no checkpoint', () => {
+    const cp = new GenerationCheckpoint()
+    const out = resolveDegradation('   ', true, cp)
+    expect(out.kind).toBe('fallback')
+  })
+
+  it('prefers current over checkpoint when both are valid', () => {
+    const cp = new GenerationCheckpoint()
+    cp.record('initial', 'old', true)
+    const out = resolveDegradation('new valid', true, cp)
+    expect(out).toEqual({ kind: 'current', code: 'new valid' })
+  })
+})

--- a/app/api/chat-ws/route.ts
+++ b/app/api/chat-ws/route.ts
@@ -10,6 +10,7 @@ import { validateGeneratedCode } from '@/lib/code-validator'
 import { buildValidationFallbackComponent } from '@/lib/validation-fallback'
 import { runValidationRetryLoop, buildRepairPrompt } from '@/lib/generation-retry'
 import { buildVerifyPrompt, buildVerifyAgentOptions } from '@/lib/agent/verify-loop'
+import { GenerationCheckpoint, resolveDegradation } from '@/lib/generation-checkpoint'
 import { stripGradients } from '@/lib/gradient-blocker'
 import { fetchContextualImages, formatImagesForPrompt, getFallbackImages } from '@/lib/services/unsplash.service'
 import { extractComponentCode } from '@/lib/agent/component-generation-tool'
@@ -843,6 +844,11 @@ OUTPUT: Generate 150-300 lines of COMPLETE, working code. Make it visually polis
           console.log('[VALIDATION] Result:', validation.valid ? '✅ valid' : '❌ invalid', 'finalContent:', finalContent.length, 'chars')
           let retryAttempted = false
 
+          // Checkpoint the last VALID version across stages so we never render a
+          // regression — worst case we serve an earlier working build (#81).
+          const checkpoint = new GenerationCheckpoint()
+          checkpoint.record('initial', finalContent, validation.valid)
+
           // AUTO-RETRY: If validation fails, automatically retry once with error feedback
           if (!validation.valid) {
             console.error('⚠️ Initial validation failed:', validation.error)
@@ -892,6 +898,7 @@ OUTPUT: Generate 150-300 lines of COMPLETE, working code. Make it visually polis
               console.log(`✅ Auto-retry succeeded after ${retryLoop.attempts} attempt(s)`)
               finalContent = retryLoop.code
               validation = retryLoop.validation
+              checkpoint.record('retry', finalContent, validation.valid)
               updatePreviewPartial(responseId, finalContent)
             } else {
               console.error(`❌ Auto-retry exhausted (${retryLoop.attempts} attempts):`, retryLoop.validation.error)
@@ -967,6 +974,7 @@ OUTPUT: Generate 150-300 lines of COMPLETE, working code. Make it visually polis
                   finalContent = agentValidation.code
                   validation = agentValidation
                   agentFallbackSucceeded = true
+                  checkpoint.record('agent', finalContent, validation.valid)
 
                   // Update preview with fixed content
                   updatePreviewPartial(responseId, finalContent)
@@ -998,7 +1006,18 @@ OUTPUT: Generate 150-300 lines of COMPLETE, working code. Make it visually polis
             }).catch(e => console.warn('[AgentRuns] fallback log failed:', e?.message || e))
           }
 
-          // Final validation check
+          // Final decision — degradation ladder (#81): serve current-if-valid,
+          // else the last checkpointed WORKING version, else a clean fallback.
+          const degradation = resolveDegradation(finalContent, validation.valid, checkpoint)
+
+          if (degradation.kind === 'checkpoint') {
+            // An earlier stage produced valid code that a later stage regressed.
+            // Serve that working version instead of an error (#81).
+            console.log(`♻️ Serving last-good checkpoint from '${degradation.stage}' stage`)
+            finalContent = degradation.code
+            validation = { valid: true, code: degradation.code }
+          }
+
           if (!validation.valid) {
             // Log validation error
             console.error('❌ Final validation failed (after retry' + (agentFallbackUsed ? ' + agent fallback' : '') + '):', validation.error)
@@ -1017,11 +1036,10 @@ OUTPUT: Generate 150-300 lines of COMPLETE, working code. Make it visually polis
                 : 'The generated code has syntax errors. Please try regenerating.'
             })}\n\n`))
 
-            // Graceful degradation (#77): do NOT ship the broken code to Sandpack
-            // (that renders the "Something went wrong" crash overlay). Instead
-            // render a clean, intentional fallback component so the preview area
-            // shows a friendly state with a regenerate affordance. The raw invalid
-            // code is still stored (behind "View problematic code") for debugging.
+            // Graceful degradation (#77/#81): with no working checkpoint, do NOT
+            // ship the broken code to Sandpack (that renders the "Something went
+            // wrong" crash overlay). Render a clean, intentional fallback state.
+            // The raw invalid code is still stored behind "View problematic code".
             const safeFallback = buildValidationFallbackComponent(message)
             const wrappedInvalidCode = `\`\`\`jsx\n${finalContent}\n\`\`\``
             storePreview(responseId, wrappedInvalidCode, message, {

--- a/lib/generation-checkpoint.ts
+++ b/lib/generation-checkpoint.ts
@@ -1,0 +1,65 @@
+/**
+ * Generation checkpointing + degradation ladder (builder#81, Phase 2).
+ *
+ * The generation pipeline has several stages that can each improve OR regress the
+ * output: initial generation, the retry loop (#77), and the verify agent (#80).
+ * To guarantee "never render broken," we checkpoint the last code that PASSED
+ * validation. At the end, the pipeline serves, in order:
+ *   1. the current code if it is valid, else
+ *   2. the last checkpointed valid code (a slightly-less-complete but WORKING
+ *      version), else
+ *   3. a clean fallback state (handled by lib/validation-fallback).
+ *
+ * This converts "1 in 4 users see a broken preview" into "worst case is a working
+ * earlier version or a clean state" — the graceful-degradation pattern.
+ */
+
+export interface Checkpoint {
+  code: string
+  stage: string
+}
+
+export class GenerationCheckpoint {
+  private best: Checkpoint | null = null
+
+  /** Record a stage's output. Only valid outputs become the checkpoint. */
+  record(stage: string, code: string, valid: boolean): void {
+    if (valid && typeof code === 'string' && code.trim().length > 0) {
+      this.best = { code, stage }
+    }
+  }
+
+  /** Whether any valid version has been captured. */
+  hasValid(): boolean {
+    return this.best !== null
+  }
+
+  /** The last valid code, or null if none. */
+  get(): Checkpoint | null {
+    return this.best
+  }
+}
+
+export type DegradationOutcome =
+  | { kind: 'current'; code: string }
+  | { kind: 'checkpoint'; code: string; stage: string }
+  | { kind: 'fallback' }
+
+/**
+ * Decide what to render given the final validation state and the checkpoint.
+ * Pure so it can be unit-tested exhaustively.
+ */
+export function resolveDegradation(
+  currentCode: string,
+  currentValid: boolean,
+  checkpoint: GenerationCheckpoint,
+): DegradationOutcome {
+  if (currentValid && currentCode.trim().length > 0) {
+    return { kind: 'current', code: currentCode }
+  }
+  const cp = checkpoint.get()
+  if (cp) {
+    return { kind: 'checkpoint', code: cp.code, stage: cp.stage }
+  }
+  return { kind: 'fallback' }
+}


### PR DESCRIPTION
## Summary
Final Phase of the reliability work — guarantees **never render broken**. The pipeline has stages that can each improve OR regress output (initial gen, retry #77, verify agent #80). We checkpoint the last code that PASSED validation, and a degradation ladder serves:
1. current code if valid, else
2. the last checkpointed **working** version (earlier-but-valid build), else
3. a clean fallback state (#77).

## Changes
- `lib/generation-checkpoint.ts` — pure `GenerationCheckpoint` + `resolveDegradation`.
- `app/api/chat-ws/route.ts` — records checkpoints after initial/retry/agent stages; consults the ladder before rendering. A later-stage regression now falls back to the earlier working version instead of an error.

## Testing
- `generation-checkpoint.ts`: **100% coverage**, 11 tests.
- **188 tests green** across all reliability modules.
- `tsc --noEmit` clean.

Closes #81