### PR TITLE
fix(build): complete pnpm build-script allowlist so Railway install exits 0

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-dangerously-allow-all-builds=true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,14 @@
+# pnpm 11+ build-script allowlist. Lists every dependency with a build script so
+# `pnpm install --frozen-lockfile` (Railway CI) exits 0 instead of failing on
+# ERR_PNPM_IGNORED_BUILDS. cody-cli's postinstall is optional but must be listed.
 onlyBuiltDependencies:
-  - "@ainative/cody-cli"
-  - "@anthropic-ai/claude-code"
+  - '@ainative/cody-cli'
+  - '@anthropic-ai/claude-code'
+  - '@sentry/cli'
+  - bufferutil
+  - es5-ext
+  - esbuild
   - protobufjs
+  - redis-memory-server
+  - sharp
+  - unrs-resolver


### PR DESCRIPTION
## Problem
PR #87 (cody-cli dep) broke the Railway build. `pnpm install --frozen-lockfile` (what Railway runs) exits **1** on `ERR_PNPM_IGNORED_BUILDS` when any dependency with a build script isn't allow-listed. The prior `pnpm-workspace.yaml` only listed 3 packages, but the frozen install needs **all** of them (`@sentry/cli`, `esbuild`, `sharp`, `bufferutil`, `es5-ext`, `redis-memory-server`, `unrs-resolver`, `protobufjs`, plus the two agent CLIs). Commit 00fcf67 never deployed as a result.

## Fix
- Complete `onlyBuiltDependencies` list in `pnpm-workspace.yaml`.
- Removed the `.npmrc dangerously-allow-all-builds` (not honored in `--frozen-lockfile` mode).

## Verified
Clean clone + `CI=true pnpm install --frozen-lockfile` → **exit 0**.