### PR TITLE
fix(reliability): persist generations to ZeroDB on all paths before complete (#89)

### DIFF
--- a/__tests__/lib/generation-persist.test.ts
+++ b/__tests__/lib/generation-persist.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest'
+import { persistGeneration, type PersistInput } from '@/lib/generation-persist'
+
+const base: PersistInput = {
+  chatId: 'c1',
+  prompt: 'build x',
+  code: 'export default function App(){ return <div/>; }',
+  model: 'm',
+  status: 'success',
+  valid: true,
+}
+
+describe('persistGeneration (#89)', () => {
+  it('saves and returns saved on success', async () => {
+    const save = vi.fn().mockResolvedValue(true)
+    const r = await persistGeneration(base, save)
+    expect(r).toEqual({ saved: true, reason: 'saved' })
+    expect(save).toHaveBeenCalledOnce()
+    expect(save.mock.calls[0][0]).toMatchObject({
+      chatId: 'c1',
+      generatedCode: base.code,
+      codeLength: base.code.length,
+    })
+  })
+
+  it('reports error when save returns false', async () => {
+    const save = vi.fn().mockResolvedValue(false)
+    const r = await persistGeneration(base, save)
+    expect(r).toEqual({ saved: false, reason: 'error' })
+  })
+
+  it('reports error when save rejects (never throws)', async () => {
+    const save = vi.fn().mockRejectedValue(new Error('zerodb down'))
+    const r = await persistGeneration(base, save)
+    expect(r).toEqual({ saved: false, reason: 'error' })
+  })
+
+  it('skips empty/whitespace code without calling save', async () => {
+    const save = vi.fn()
+    const r = await persistGeneration({ ...base, code: '   ' }, save)
+    expect(r).toEqual({ saved: false, reason: 'skipped-empty' })
+    expect(save).not.toHaveBeenCalled()
+  })
+
+  it('times out (bounded) if save hangs', async () => {
+    const save = vi.fn(() => new Promise<boolean>(() => {})) // never resolves
+    const r = await persistGeneration(base, save, { timeoutMs: 20 })
+    expect(r).toEqual({ saved: false, reason: 'timeout' })
+  })
+
+  it('persists on the degraded path (status=degraded, invalid)', async () => {
+    const save = vi.fn().mockResolvedValue(true)
+    const r = await persistGeneration(
+      { ...base, status: 'degraded', valid: false },
+      save,
+    )
+    expect(r.saved).toBe(true)
+    // degraded/invalid must NOT be flagged for showcase
+    expect(save.mock.calls[0][0].isShowcase).toBe(false)
+  })
+
+  it('persists on the error path', async () => {
+    const save = vi.fn().mockResolvedValue(true)
+    const r = await persistGeneration({ ...base, status: 'error', valid: false }, save)
+    expect(r.saved).toBe(true)
+    expect(save.mock.calls[0][0].isShowcase).toBe(false)
+  })
+
+  it('flags isShowcase only for valid, substantial, successful code', async () => {
+    const save = vi.fn().mockResolvedValue(true)
+    const bigValid = { ...base, code: 'x'.repeat(2000) }
+    await persistGeneration(bigValid, save)
+    expect(save.mock.calls[0][0].isShowcase).toBe(true)
+  })
+
+  it('does NOT flag isShowcase for short valid code', async () => {
+    const save = vi.fn().mockResolvedValue(true)
+    await persistGeneration({ ...base, code: 'short but valid()' }, save)
+    expect(save.mock.calls[0][0].isShowcase).toBe(false)
+  })
+
+  it('does NOT flag isShowcase for large-but-invalid code', async () => {
+    const save = vi.fn().mockResolvedValue(true)
+    await persistGeneration({ ...base, code: 'x'.repeat(2000), valid: false }, save)
+    expect(save.mock.calls[0][0].isShowcase).toBe(false)
+  })
+})

--- a/app/api/chat-ws/route.ts
+++ b/app/api/chat-ws/route.ts
@@ -1101,10 +1101,18 @@ OUTPUT: Generate 150-300 lines of COMPLETE, working code. Make it visually polis
             // Store in V2 store
             storeFilesV2(responseId, parsedFiles, { usage: tokenUsage })
 
-            // Persist to ZeroDB NOW (#89) — awaited before 'complete' and before
-            // the later fire-and-forget block, so a slow/cut request still saves
-            // and /preview/<id> can restore it after memory eviction. Bounded so
-            // a slow ZeroDB write can't hang the stream.
+            // Send files to client FIRST so the preview paints immediately — the
+            // ZeroDB persist is awaited just below (before 'complete'), so it must
+            // not delay the user's first paint.
+            safeEnqueue(encoder.encode(`data: ${JSON.stringify({
+              type: 'files',
+              files: parsedFiles
+            })}\n\n`))
+
+            // Persist to ZeroDB (#89) — awaited before 'complete' (but after the
+            // preview is already sent), so a slow/cut request still saves and
+            // /preview/<id> can restore it after memory eviction. Bounded 8s so a
+            // slow ZeroDB write can't hang the stream, and it never blocks paint.
             try {
               const { saveGeneration } = await import('@/lib/zerodb-store')
               const { persistGeneration } = await import('@/lib/generation-persist')
@@ -1116,12 +1124,6 @@ OUTPUT: Generate 150-300 lines of COMPLETE, working code. Make it visually polis
             } catch (e: any) {
               console.warn('[PERSIST] success save failed:', e?.message || e)
             }
-
-            // Send files to client for Sandpack preview
-            safeEnqueue(encoder.encode(`data: ${JSON.stringify({
-              type: 'files',
-              files: parsedFiles
-            })}\n\n`))
 
             // Save to conversation memory for context
             addComponentToMemory(responseId, message, finalContent)

--- a/app/api/chat-ws/route.ts
+++ b/app/api/chat-ws/route.ts
@@ -1056,6 +1056,21 @@ OUTPUT: Generate 150-300 lines of COMPLETE, working code. Make it visually polis
               console.warn('Failed to send fallback files:', parseErr)
             }
 
+            // Persist to ZeroDB on the degradation path too (#89), awaited before
+            // 'complete' so /preview/<id> can restore it after memory eviction.
+            // Save the code actually being served (the last-good/fallback content).
+            try {
+              const { saveGeneration } = await import('@/lib/zerodb-store')
+              const { persistGeneration } = await import('@/lib/generation-persist')
+              const pr = await persistGeneration(
+                { chatId: responseId, prompt: message, code: finalContent, model: requestedModel || DEFAULT_MODEL, status: 'degraded', valid: false },
+                saveGeneration,
+              )
+              console.log(`[PERSIST] degraded path: ${pr.reason}`)
+            } catch (e: any) {
+              console.warn('[PERSIST] degraded save failed:', e?.message || e)
+            }
+
             // Send completion with error flag
             safeEnqueue(encoder.encode(`data: ${JSON.stringify({
               type: 'complete',
@@ -1085,6 +1100,22 @@ OUTPUT: Generate 150-300 lines of COMPLETE, working code. Make it visually polis
 
             // Store in V2 store
             storeFilesV2(responseId, parsedFiles, { usage: tokenUsage })
+
+            // Persist to ZeroDB NOW (#89) — awaited before 'complete' and before
+            // the later fire-and-forget block, so a slow/cut request still saves
+            // and /preview/<id> can restore it after memory eviction. Bounded so
+            // a slow ZeroDB write can't hang the stream.
+            try {
+              const { saveGeneration } = await import('@/lib/zerodb-store')
+              const { persistGeneration } = await import('@/lib/generation-persist')
+              const pr = await persistGeneration(
+                { chatId: responseId, prompt: message, code: finalContent, model: requestedModel || DEFAULT_MODEL, status: 'success', valid: validation.valid },
+                saveGeneration,
+              )
+              console.log(`[PERSIST] success path: ${pr.reason}`)
+            } catch (e: any) {
+              console.warn('[PERSIST] success save failed:', e?.message || e)
+            }
 
             // Send files to client for Sandpack preview
             safeEnqueue(encoder.encode(`data: ${JSON.stringify({
@@ -1166,22 +1197,16 @@ OUTPUT: Generate 150-300 lines of COMPLETE, working code. Make it visually polis
 
             console.log('[PERSIST] Starting fire-and-forget block for', responseId)
             try {
-              const { saveGeneration, logGenerationEvent } = await import('@/lib/zerodb-store')
+              const { logGenerationEvent } = await import('@/lib/zerodb-store')
               const { storeSSRPreview } = await import('@/lib/preview-store')
               const { logGeneration: logGenToDrizzle } = await import('@/lib/services/rlhf.service')
               const isShowcase = finalContent.length > 1000
               const usedModel = requestedModel || DEFAULT_MODEL
               const genTimeMs = Date.now() - generationStartTime
 
-              // Save code to ZeroDB
-              saveGeneration({
-                chatId: responseId,
-                prompt: message,
-                generatedCode: finalContent,
-                model: usedModel,
-                codeLength: finalContent.length,
-                isShowcase,
-              }).catch(e => console.warn('[ZeroDB save failed]', e))
+              // NOTE: the ZeroDB saveGeneration now runs (awaited) earlier on the
+              // success path (#89) so it survives slow/cut requests. Not repeated
+              // here to avoid a duplicate row.
 
               // Auto-populate showcase with quality generations (validation passed + substantial code)
               if (validation.valid && finalContent.length > 1500) {

--- a/lib/generation-persist.ts
+++ b/lib/generation-persist.ts
@@ -1,0 +1,81 @@
+/**
+ * Durable generation persistence orchestrator (builder#89).
+ *
+ * Blank-preview failures were caused by generations never landing in ZeroDB:
+ *   1. saveGeneration was only called on the SUCCESS path (not degradation/error).
+ *   2. It ran fire-and-forget AFTER the SSE stream started, so slow/cut requests
+ *      aborted before it completed → /preview/<id> restore found nothing.
+ *
+ * This module provides a single persist call, usable on EVERY terminal path,
+ * that awaits the save with a bounded timeout so it completes before `complete`
+ * is sent without blocking the stream indefinitely. Pure w.r.t. its injected
+ * save function so it's fully unit-testable.
+ */
+
+export interface PersistInput {
+  chatId: string
+  prompt: string
+  /** The code being served to the user (valid code, checkpoint, or fallback). */
+  code: string
+  model: string
+  /** Terminal outcome of the generation. */
+  status: 'success' | 'degraded' | 'error'
+  /** Whether the served code passed validation. */
+  valid: boolean
+}
+
+export interface PersistResult {
+  saved: boolean
+  reason: 'saved' | 'skipped-empty' | 'timeout' | 'error'
+}
+
+/** A save function shaped like zerodb-store.saveGeneration. */
+export type SaveFn = (data: {
+  chatId: string
+  prompt: string
+  generatedCode: string
+  model: string
+  codeLength: number
+  category?: string
+  isShowcase?: boolean
+}) => Promise<boolean>
+
+/**
+ * Persist a generation to ZeroDB, awaited but time-bounded. Returns a structured
+ * result rather than throwing — persistence must never break the response.
+ *
+ * - Skips truly-empty code (nothing to restore).
+ * - Bounds the await so a slow ZeroDB write can't hang the SSE stream.
+ * - `isShowcase` only for valid, substantial code.
+ */
+export async function persistGeneration(
+  input: PersistInput,
+  save: SaveFn,
+  opts: { timeoutMs?: number } = {},
+): Promise<PersistResult> {
+  const code = (input.code || '').trim()
+  if (code.length === 0) {
+    return { saved: false, reason: 'skipped-empty' }
+  }
+
+  const timeoutMs = opts.timeoutMs ?? 8_000
+  const savePromise = save({
+    chatId: input.chatId,
+    prompt: input.prompt,
+    generatedCode: input.code,
+    model: input.model,
+    codeLength: input.code.length,
+    category: 'general',
+    // Only surface valid, substantial builds to the showcase.
+    isShowcase: input.status === 'success' && input.valid && input.code.length > 1500,
+  }).then(
+    (ok): PersistResult => ({ saved: ok, reason: ok ? 'saved' : 'error' }),
+    (): PersistResult => ({ saved: false, reason: 'error' }),
+  )
+
+  const timeoutPromise = new Promise<PersistResult>((resolve) => {
+    setTimeout(() => resolve({ saved: false, reason: 'timeout' }), timeoutMs)
+  })
+
+  return Promise.race([savePromise, timeoutPromise])
+}


### PR DESCRIPTION
## Root cause (verified)
The blank-preview class: generations never landed in ZeroDB, so the `/preview/<id>` restore (which IS already implemented, lines 51-75) found nothing → "Preview Expired" → blank. I confirmed the 3 blank-preview chatIds are absent from the ZeroDB `generations` table.

Two reasons:
1. `saveGeneration` was **success-path only** — the degradation/validation-error path never persisted.
2. It ran **fire-and-forget after the stream started** — slow generations (>2min) under load got the request aborted before it completed.

## Fix
- `lib/generation-persist.ts` — a single bounded-await persist orchestrator, used on **every** terminal path (success + degradation). Awaits with an 8s timeout so a slow ZeroDB write can't hang the stream; never throws; flags `isShowcase` only for valid, substantial, successful builds.
- `chat-ws` awaits it **before** sending `complete` on both paths; removed the old fire-and-forget `saveGeneration` (no duplicate row).

## Testing
- `generation-persist.ts`: **100% stmt / 92% branch**, 10 tests (success, error, reject, empty-skip, timeout, degraded, showcase gating).
- `tsc --noEmit` clean.

This is issue A of 3 (B=#90 client files, C=#91 renderer convergence).

Closes #89