### PR TITLE
fix(build): pin pnpm@10.15.0 to unblock Railway deploy (all deploys blocked since #87)

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,5 +133,6 @@
     "ts-jest": "^29.4.4",
     "tw-animate-css": "^1.3.7",
     "typescript": "^5"
-  }
+  },
+  "packageManager": "pnpm@10.15.0"
 }


### PR DESCRIPTION
## Critical: nothing has deployed since #87
Prod stuck on `7524a88`. The cody-cli dep triggered pnpm 11's fatal `ERR_PNPM_IGNORED_BUILDS` on `install --frozen-lockfile` (exit 1) — which `onlyBuiltDependencies` alone doesn't suppress in CI. This blocked the reliability (#76-#81) and ZeroDB persistence (#89) fixes from ever reaching users.

## Fix
pnpm 10 does NOT hard-fail on ignored build scripts. Pinned `"packageManager": "pnpm@10.15.0"` so Railway uses it. Also cleaned the corrupt `allowBuilds` placeholder from `pnpm-workspace.yaml` and removed the non-working `.npmrc`.

## Verified (fresh clone)
```
pnpm@10.15.0 install --frozen-lockfile  →  exit 0  ✅
```
(pnpm 11.5.3 → exit 1; pnpm 10.15.0 → exit 0, cody-cli present)

Unblocks #76-#81 + #89.