### PR TITLE
fix: correct Sonnet 3.5→4 label + fix sweep Sandpack-wait timing

### DIFF
--- a/app/api/chat-ws/route.ts
+++ b/app/api/chat-ws/route.ts
@@ -57,7 +57,7 @@ function getLLMClient(): OpenAI {
 }
 
 // Model strategy (updated 2026-06-27):
-// PRIMARY: Claude Sonnet 3.5 via Anthropic SDK (200K context, best code quality)
+// PRIMARY: Claude Sonnet 4 via Anthropic SDK (200K context, best code quality)
 // FALLBACK: ministral-14b via AINative (free, fast, limited context)
 // Enable Claude direct when a real Anthropic key is set (sk-ant- prefix)
 const USE_CLAUDE_DIRECT = !!(process.env.ANTHROPIC_API_KEY && process.env.ANTHROPIC_API_KEY.startsWith('sk-ant-'))
@@ -601,7 +601,7 @@ IMPORT RULES:
 
 OUTPUT: Generate 150-300 lines of COMPLETE, working code. Make it visually polished with realistic sample data.`
 
-            safeEnqueue(encoder.encode(`data: ${JSON.stringify({ type: 'build_step', step: 'Generating with ' + (USE_CLAUDE_DIRECT ? 'Claude Sonnet 3.5' : modelId) + '...' })}\n\n`))
+            safeEnqueue(encoder.encode(`data: ${JSON.stringify({ type: 'build_step', step: 'Generating with ' + (USE_CLAUDE_DIRECT ? 'Claude Sonnet 4' : modelId) + '...' })}\n\n`))
 
             // ============ CLAUDE DIRECT PATH — Anthropic SDK ============
             const claude = getAnthropicClient()
@@ -632,7 +632,7 @@ OUTPUT: Generate 150-300 lines of COMPLETE, working code. Make it visually polis
                   estimated_cost: ((usage?.input_tokens || 0) * 0.000003 + (usage?.output_tokens || 0) * 0.000015),
                 }
 
-                console.log(`📊 Claude Sonnet 3.5: ${fullContent.length} chars (${tokenUsage.input_tokens}+${tokenUsage.output_tokens} tok) cost=$${tokenUsage.estimated_cost.toFixed(4)}`)
+                console.log(`📊 Claude Sonnet 4: ${fullContent.length} chars (${tokenUsage.input_tokens}+${tokenUsage.output_tokens} tok) cost=$${tokenUsage.estimated_cost.toFixed(4)}`)
 
                 updatePreviewPartial(responseId, fullContent)
                 safeEnqueue(encoder.encode(`data: ${JSON.stringify({ type: 'refresh' })}\n\n`))

--- a/e2e/reliability-sweep.spec.ts
+++ b/e2e/reliability-sweep.spec.ts
@@ -66,18 +66,35 @@ test.describe('reliability sweep (production)', () => {
         )
         .toBe(true)
 
-      await page.waitForTimeout(9_000) // let Sandpack compile+mount
-
+      // Actively wait for Sandpack to finish compiling+mounting — not a fixed
+      // sleep. Poll the preview frame until it has real rendered content OR an
+      // error overlay appears, up to 40s (Sandpack cold-boot can be slow).
       let errorSeen = ''
       let previewEls = 0
-      for (const frame of page.frames()) {
-        const txt = (await frame.locator('body').innerText().catch(() => '')) || ''
-        if (ERROR_RE.test(txt)) { errorSeen = txt.replace(/\s+/g, ' ').slice(0, 140); break }
-        if (/sandpack|codesandbox|\/preview\//i.test(frame.url())) {
-          const c = await frame.locator('button, input, a, h1, h2, h3, li, img, form, table').count().catch(() => 0)
-          previewEls = Math.max(previewEls, c)
-        }
-      }
+      await expect
+        .poll(
+          async () => {
+            for (const frame of page.frames()) {
+              const txt = (await frame.locator('body').innerText().catch(() => '')) || ''
+              if (ERROR_RE.test(txt)) {
+                errorSeen = txt.replace(/\s+/g, ' ').slice(0, 140)
+                return 'error'
+              }
+              // Sandpack shows "[N/N] Starting" / a bundler status while booting.
+              if (/\[\d\/\d\]\s*(Starting|Installing|Building)/i.test(txt)) continue
+              if (/sandpack|codesandbox|\/preview\//i.test(frame.url())) {
+                const c = await frame
+                  .locator('button, input, a, h1, h2, h3, li, img, form, table')
+                  .count()
+                  .catch(() => 0)
+                if (c > 0) { previewEls = Math.max(previewEls, c); return 'rendered' }
+              }
+            }
+            return 'pending'
+          },
+          { timeout: 40_000, intervals: [2_000] },
+        )
+        .not.toBe('pending')
 
       await page.screenshot({ path: `sweep-${String(i + 1).padStart(2, '0')}.png` }).catch(() => {})
       const ok = !errorSeen && previewEls > 0


### PR DESCRIPTION
- The app generates with `claude-sonnet-4-20250514` but the build-step UI and logs said 'Claude Sonnet 3.5'. Corrected.
- The reliability sweep screenshotted Sandpack mid-boot ('[N/N] Starting'), causing false negatives (e.g. the todo app looked blank but rendered fine a second later). Replaced the fixed 9s wait with an active poll for real content or an error overlay (up to 40s).