### PR TITLE
fix(CRITICAL): correct Claude model ID (was 404→gpt-oss-20b) + gate agent auto-activation

### DIFF
--- a/app/api/chat-ws/route.ts
+++ b/app/api/chat-ws/route.ts
@@ -246,7 +246,13 @@ export async function POST(request: NextRequest) {
           //      is set (auto-activate for complex/multi-file prompts)
           // ============================================================
           const agentExplicitlyEnabled = isClaudeAgentEnabled()
-          const agentAutoActivated = complexityScore.shouldUseAgent && !!process.env.ANTHROPIC_API_KEY
+          // Auto-activate for complex prompts ONLY when the agent runtime is
+          // actually enabled — a raw ANTHROPIC_API_KEY check let complex prompts
+          // spawn a failing agent even when it was meant to be off (builder#99).
+          const agentAutoActivated =
+            complexityScore.shouldUseAgent &&
+            !!process.env.ANTHROPIC_API_KEY &&
+            isClaudeAgentEnabled()
           const useAgent = agentExplicitlyEnabled || agentAutoActivated
 
           // Tier-based maxTurns:

--- a/app/api/chat-ws/route.ts
+++ b/app/api/chat-ws/route.ts
@@ -61,7 +61,11 @@ function getLLMClient(): OpenAI {
 // FALLBACK: ministral-14b via AINative (free, fast, limited context)
 // Enable Claude direct when a real Anthropic key is set (sk-ant- prefix)
 const USE_CLAUDE_DIRECT = !!(process.env.ANTHROPIC_API_KEY && process.env.ANTHROPIC_API_KEY.startsWith('sk-ant-'))
-const DEFAULT_MODEL = USE_CLAUDE_DIRECT ? 'claude-sonnet-4-20250514' : (process.env.DEFAULT_MODEL || 'ministral-14b')
+// CRITICAL: the Anthropic key only has Sonnet 4.5 access — the old
+// 'claude-sonnet-4-20250514' ID 404s, silently forcing every generation onto the
+// gpt-oss-20b fallback (mislabeled as claude). Use the working ID, env-overridable.
+const CLAUDE_MODEL = process.env.CLAUDE_MODEL || 'claude-sonnet-4-5-20250929'
+const DEFAULT_MODEL = USE_CLAUDE_DIRECT ? CLAUDE_MODEL : (process.env.DEFAULT_MODEL || 'ministral-14b')
 const PAID_MODEL = process.env.PAID_MODEL || 'kimi-k2.6'
 
 // Anthropic client for direct Claude calls — lazy initialized on first use
@@ -609,7 +613,7 @@ OUTPUT: Generate 150-300 lines of COMPLETE, working code. Make it visually polis
               console.log('🧠 Using Claude Sonnet 4 directly via Anthropic SDK')
               try {
                 const claudeResponse = await claude.messages.create({
-                  model: 'claude-sonnet-4-20250514',
+                  model: CLAUDE_MODEL,
                   max_tokens: 8192,
                   system: llmSystemPrompt,
                   messages: previousMessages.length > 0

--- a/lib/agent/subagents.ts
+++ b/lib/agent/subagents.ts
@@ -85,7 +85,7 @@ Provide structured spec:
 
   try {
     const response = await anthropic.messages.create({
-      model: 'claude-sonnet-4-20250514',
+      model: (process.env.CLAUDE_MODEL || 'claude-sonnet-4-5-20250929'),
       max_tokens: 4000, // Must be > thinking budget
       temperature: 1,
       thinking: {
@@ -155,7 +155,7 @@ Use generate_react_component tool for output. Gradients/emoji stripped automatic
 
   try {
     const response = await anthropic.messages.create({
-      model: 'claude-sonnet-4-20250514',
+      model: (process.env.CLAUDE_MODEL || 'claude-sonnet-4-5-20250929'),
       max_tokens: 8000,
       temperature: 1,
       thinking: {
@@ -247,7 +247,7 @@ Report:
 
   try {
     const response = await anthropic.messages.create({
-      model: 'claude-sonnet-4-20250514',
+      model: (process.env.CLAUDE_MODEL || 'claude-sonnet-4-5-20250929'),
       max_tokens: 1500,
       temperature: 0.3,
       messages: [
@@ -309,7 +309,7 @@ export async function runOrchestratorAgent(
   metrics?: any
 }> {
   // Initialize metrics collector
-  const model = 'claude-sonnet-4-20250514'
+  const model = (process.env.CLAUDE_MODEL || 'claude-sonnet-4-5-20250929')
   const metricsCollector = createMetricsCollector(
     sessionId || `session-${Date.now()}`,
     userPrompt,


### PR DESCRIPTION
## #98 — CRITICAL: apps were NOT built by Claude
Every generation 404'd on `claude-sonnet-4-20250514` (key only has Sonnet 4.5), silently falling through to **gpt-oss-20b** while logging it as Claude. Fix: `CLAUDE_MODEL` env (default `claude-sonnet-4-5-20250929`, verified working on the key) across chat-ws + subagents. Single biggest quality lever.

## #99 — agent auto-activation gated
Complex prompts spawned a failing cody agent (reason=tool_use, $0.13/44s, no output) whenever ANTHROPIC_API_KEY was set, ignoring the flags. Now respects `isClaudeAgentEnabled()`.

Env set on Railway: CLAUDE_MODEL=claude-sonnet-4-5-20250929, cody flags off until #99 root-caused.

Closes #98