### PR TITLE
fix(preview): stop false 'Element type is invalid' on import-stripped code (#91)

### DIFF
--- a/__tests__/lib/undefined-components.test.ts
+++ b/__tests__/lib/undefined-components.test.ts
@@ -95,4 +95,22 @@ describe('findUnresolvedComponents (#76)', () => {
     ].join('\n')
     expect(validateJavaScriptCode(code).valid).toBe(true)
   })
+
+  // #91: the /preview/[id] Babel renderer strips imports and injects components
+  // as globals. On that path every component looks "unresolved" — the #76 check
+  // must NOT run when there are no imports, or it wrongly rejects valid apps.
+  it('does NOT flag components in import-stripped code (globals-injection context)', () => {
+    const code = [
+      'function App(){ return <div><ThumbsUp/><BarChart/><Badge>x</Badge><CustomWidget/></div>; }',
+      'export default App;',
+    ].join('\n')
+    expect(validateJavaScriptCode(code).valid).toBe(true)
+  })
+
+  it('STILL flags hallucinated components when imports are present', () => {
+    const code = "import React from 'react'\nexport default function App(){ return <div><Header/></div>; }"
+    const r = validateJavaScriptCode(code)
+    expect(r.valid).toBe(false)
+    expect(r.error).toMatch(/Header/)
+  })
 })

--- a/lib/code-validator.ts
+++ b/lib/code-validator.ts
@@ -584,10 +584,13 @@ export function validateJavaScriptCode(code: string): ValidationResult {
   }
 
   // Catch hallucinated components — used in JSX but never defined, imported, or
-  // in the known-available set. These render as "Element type is invalid:
-  // … got: undefined" at runtime (Sandpack), which the Babel parse cannot see.
-  // Reject so retry re-generates rather than shipping a broken preview (#76).
-  const unresolved = findUnresolvedComponents(fixedCode)
+  // in the known-available set (#76). ONLY when the code has imports: the
+  // /preview/[id] Babel renderer STRIPS all imports and injects components as
+  // globals, so on that path every component would look "unresolved" — a false
+  // positive that wrongly rejected valid apps (#91). If there are no imports,
+  // assume a globals-injection context and skip this check.
+  const hasImports = /^\s*import\s/m.test(fixedCode)
+  const unresolved = hasImports ? findUnresolvedComponents(fixedCode) : []
   if (unresolved.length > 0) {
     const errorMessage = `Element type is invalid: <${unresolved[0]}> is used but not defined or imported`
     console.error('❌ Code validation failed (unresolved component):', unresolved.join(', '))


### PR DESCRIPTION
Complex apps (RLHF, ZeroInvoice, knowledge graph, content feed) fell to the 'Refining your app' fallback despite passing generation validation. Root cause: the /preview/[id] Babel renderer strips imports (components are injected globals) then validates — so the #76 unresolved-component check flagged every component as 'unresolved' and rejected valid apps. Fix: only run that check when imports are present. Recovers the complex-app fallbacks. 43 validator tests.