### PR TITLE
fix: eliminate complex-app fallbacks (method-chain corruption + #91 + ZeroDB determinism)

### DIFF
--- a/__tests__/lib/code-validator-method-chain.test.ts
+++ b/__tests__/lib/code-validator-method-chain.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+import { validateGeneratedCode, validateJavaScriptCode } from '@/lib/code-validator'
+
+/**
+ * Regression: a stray `;` splitting a multi-line method chain
+ *   const filtered = items;
+ *     .filter(...).map(...)
+ * parses under Babel's errorRecovery but Sandpack rejects it with
+ * "Unexpected token", which dropped the whole app to the validation-fallback
+ * ("Refining your app") screen. This was the #1 cause of complex-app fallbacks
+ * (ZeroInvoice, content-feed, knowledge-graph) — filter/map/reduce chains are
+ * everywhere. Two parts: (1) the Fix-9 semicolon-inserter must NOT create it,
+ * (2) the auto-fixer must REPAIR it if already present.
+ */
+describe('method-chain semicolon corruption', () => {
+  it('Fix-9 does NOT append a ; when the value continues on the next line (.chain)', () => {
+    const code = [
+      "import React from 'react'",
+      'export default function App() {',
+      '  const items = [1,2,3]',
+      '  const total = items',
+      '    .filter(n => n > 1)',
+      '    .reduce((a,b) => a + b, 0)',
+      '  return <div>{total}</div>',
+      '}',
+    ].join('\n')
+    const r = validateJavaScriptCode(code)
+    expect(r.valid).toBe(true)
+    // the declaration must not have been terminated before the chain
+    expect(r.code).not.toMatch(/const total = items;\s*\n\s*\.filter/)
+  })
+
+  it('repairs a stray ; already splitting a chain (const x = arr;\\n.filter)', () => {
+    const code = [
+      "import React from 'react'",
+      'export default function App() {',
+      '  const invoices = [{status:"paid",total:5},{status:"pending",total:9}]',
+      '  const outstanding = invoices;',
+      "    .filter(inv => inv.status !== 'paid')",
+      '    .reduce((s, inv) => s + inv.total, 0)',
+      '  return <div>{outstanding}</div>',
+      '}',
+    ].join('\n')
+    const r = validateJavaScriptCode(code)
+    expect(r.valid).toBe(true)
+    expect(r.code).not.toMatch(/invoices;\s*\n\s*\.filter/)
+  })
+
+  it('does NOT append ; when an arrow value opens on this line and closes later', () => {
+    // const m = nodes.filter(node =>   (continues next line)
+    const code = [
+      "import React from 'react'",
+      'export default function App() {',
+      '  const nodes = [{label:"A"}]',
+      '  const matches = nodes.filter(node =>',
+      '    node.label.toLowerCase().includes("a")',
+      '  )',
+      '  return <div>{matches.length}</div>',
+      '}',
+    ].join('\n')
+    const r = validateJavaScriptCode(code)
+    expect(r.valid).toBe(true)
+    expect(r.code).not.toMatch(/node =>\s*;/)
+  })
+
+  it('STILL terminates a genuine single-line declaration (no false skip)', () => {
+    const code = [
+      "import React from 'react'",
+      'export default function App() {',
+      '  const name = "hello"',
+      '  const count = 42',
+      '  return <div>{name}{count}</div>',
+      '}',
+    ].join('\n')
+    const r = validateJavaScriptCode(code)
+    expect(r.valid).toBe(true)
+  })
+
+  it('end-to-end: a data app with a filter/map/reduce chain validates (was fallback)', () => {
+    const md = [
+      '```tsx',
+      "import React, { useState } from 'react'",
+      'export default function App() {',
+      '  const [q, setQ] = useState("")',
+      '  const items = [{name:"a",price:2},{name:"b",price:8}]',
+      '  const filtered = items',
+      '    .filter(i => i.name.includes(q))',
+      '    .map(i => ({ ...i, tax: i.price * 0.1 }))',
+      '  const total = filtered',
+      '    .reduce((s, i) => s + i.price, 0)',
+      '  return <div><input value={q} onChange={e => setQ(e.target.value)} />{total}</div>',
+      '}',
+      '```',
+    ].join('\n')
+    const r = validateGeneratedCode(md)
+    expect(r.valid).toBe(true)
+  })
+})

--- a/__tests__/lib/undefined-components.test.ts
+++ b/__tests__/lib/undefined-components.test.ts
@@ -97,20 +97,28 @@ describe('findUnresolvedComponents (#76)', () => {
   })
 
   // #91: the /preview/[id] Babel renderer strips imports and injects components
-  // as globals. On that path every component looks "unresolved" — the #76 check
-  // must NOT run when there are no imports, or it wrongly rejects valid apps.
-  it('does NOT flag components in import-stripped code (globals-injection context)', () => {
+  // as globals. On that path every component looks "unresolved" — that caller
+  // passes importsStripped:true so the #76 check is skipped and valid apps are
+  // not wrongly rejected.
+  it('does NOT flag components when importsStripped:true (globals-injection context)', () => {
     const code = [
       'function App(){ return <div><ThumbsUp/><BarChart/><Badge>x</Badge><CustomWidget/></div>; }',
       'export default App;',
     ].join('\n')
-    expect(validateJavaScriptCode(code).valid).toBe(true)
+    expect(validateJavaScriptCode(code, { importsStripped: true }).valid).toBe(true)
   })
 
-  it('STILL flags hallucinated components when imports are present', () => {
-    const code = "import React from 'react'\nexport default function App(){ return <div><Header/></div>; }"
-    const r = validateJavaScriptCode(code)
-    expect(r.valid).toBe(false)
-    expect(r.error).toMatch(/Header/)
+  // The generation path does NOT strip imports, so #76 still catches a
+  // hallucinated component even when the snippet happens to have no import line.
+  it('STILL flags a hallucinated component on the default (non-stripped) path', () => {
+    const noImport = 'export default function App(){ return <div><Header/></div>; }'
+    const r1 = validateJavaScriptCode(noImport)
+    expect(r1.valid).toBe(false)
+    expect(r1.error).toMatch(/Header/)
+
+    const withImport = "import React from 'react'\nexport default function App(){ return <div><Header/></div>; }"
+    const r2 = validateJavaScriptCode(withImport)
+    expect(r2.valid).toBe(false)
+    expect(r2.error).toMatch(/Header/)
   })
 })

--- a/app/api/chat-ws/route.ts
+++ b/app/api/chat-ws/route.ts
@@ -609,6 +609,17 @@ DATA / PERSISTENCE (AINative ZeroDB — serverless, no setup):
 - When the user asks to "save", "persist", "store", or use "a database", you MUST use /api/db (NOT localStorage, NOT an in-memory array).
 - NEVER use localStorage for persistence, and NEVER write a backend/server or connect a database (no postgres, pg, Prisma, Supabase, Firebase, Mongo).
 - For a purely presentational page (static dashboard, landing page), plain useState with sample data is fine — don't force a data layer.
+- COPY THIS EXACT PATTERN whenever data must persist (e.g. "todos that save to a database"):
+\`\`\`
+const [items, setItems] = useState([])
+useEffect(() => { fetch('/api/db/todos').then(r => r.json()).then(d => setItems(d.data || [])) }, [])
+const add = async (text) => {
+  const res = await fetch('/api/db/todos', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ text, done:false }) })
+  const created = (await res.json()).data
+  setItems(prev => [...prev, created])
+}
+const remove = async (id) => { await fetch(\`/api/db/todos?id=\${id}\`, { method:'DELETE' }); setItems(prev => prev.filter(i => i.id !== id)) }
+\`\`\`
 
 IMPORT RULES:
 - import React from 'react'

--- a/app/api/preview/[id]/route.ts
+++ b/app/api/preview/[id]/route.ts
@@ -443,7 +443,10 @@ export async function GET(
   const streaming = isPreviewStreaming(id)
   if (!streaming) {
     // Only validate when streaming is complete
-    const validation = validateJavaScriptCode(componentCode)
+    // Imports were stripped above (globals-injection renderer), so skip the
+    // #76 unresolved-component check here — every component looks unresolved
+    // once imports are gone. #91.
+    const validation = validateJavaScriptCode(componentCode, { importsStripped: true })
     if (!validation.valid) {
       console.error('Preview validation failed for ID:', id, 'Error:', validation.error)
       const errorHtml = `

--- a/lib/code-validator.ts
+++ b/lib/code-validator.ts
@@ -139,6 +139,21 @@ function autoFixCode(code: string): { code: string; fixes: string[] } {
     fixes.push('Removed stray semicolon splitting a ternary expression')
   }
 
+  // Fix METHOD-CHAIN SPLIT: a stray `;` directly before a line that begins with
+  // `.` breaks a multi-line method chain, e.g.
+  //   const filtered = items;
+  //     .filter(...).map(...)
+  // Babel's errorRecovery accepts it but Sandpack rejects with "Unexpected
+  // token", which drops the whole app to the validation-fallback screen. Drop a
+  // `;` that immediately precedes a continuation line starting with a member
+  // access. (builder: multi-line-chain corruption — the #1 cause of complex-app
+  // fallbacks: filter/map/reduce chains are everywhere.)
+  const beforeChainFix = fixedCode
+  fixedCode = fixedCode.replace(/;[ \t]*(\r?\n\s*\.)/g, '$1')
+  if (fixedCode !== beforeChainFix) {
+    fixes.push('Removed stray semicolon splitting a method chain')
+  }
+
   // Fix CONTINUATION DUPLICATION: Remove duplicate jsx markers from continuation stitching
   // e.g. ```jsx appearing mid-code from continuation
   fixedCode = fixedCode.replace(/```jsx?\s*\n/g, (match, offset) => {
@@ -237,9 +252,38 @@ function autoFixCode(code: string): { code: string; fixes: string[] } {
   )
 
   // Fix 9: Ensure all statements end with semicolon or newline (helps Babel parser)
-  // Add semicolons after const/let/var declarations if missing
-  // BUT DON'T add semicolons after opening braces/brackets!
-  fixedCode = fixedCode.replace(/^(\s*(?:const|let|var)\s+[^=]+=\s*[^;\n{[\]]+)$/gm, '$1;')
+  // Add semicolons after const/let/var declarations if missing.
+  // BUT DON'T add a semicolon when the declaration's value CONTINUES on the next
+  // line — a multi-line method chain (`const x = items\n  .filter(...)`) or an
+  // unbalanced/open expression (`const m = arr.filter(node =>` … on the next
+  // line). Appending `;` there splits the expression and produces "Unexpected
+  // token" — which then fails validation and drops the whole app to the
+  // fallback screen. (builder: multi-line-chain corruption.)
+  {
+    const declRe = /^(\s*(?:const|let|var)\s+[^=]+=\s*[^;\n{[\]]+)$/
+    // Tokens that, at the START of the following line, mean the expression is
+    // still going: member access, ternary/label, closers, binary operators,
+    // template/comma continuation, or an opening paren (call continuation).
+    const continuationRe = /^\s*[.?:)\]}&|+\-*/=,`(]/
+    const dfLines = fixedCode.split('\n')
+    for (let i = 0; i < dfLines.length; i++) {
+      const m = dfLines[i].match(declRe)
+      if (!m) continue
+      // Balance check: if this line has more opens than closes, the expression
+      // spills onto later lines — never terminate it here.
+      const opens = (dfLines[i].match(/[([{]/g) || []).length
+      const closes = (dfLines[i].match(/[)\]}]/g) || []).length
+      if (opens > closes) continue
+      // Trailing binary/arrow operator also means "to be continued".
+      if (/(=>|[+\-*/%&|<>=?:.,])\s*$/.test(dfLines[i])) continue
+      // Peek at the next non-blank line; if it continues the expression, skip.
+      let j = i + 1
+      while (j < dfLines.length && dfLines[j].trim() === '') j++
+      if (j < dfLines.length && continuationRe.test(dfLines[j])) continue
+      dfLines[i] = m[1] + ';'
+    }
+    fixedCode = dfLines.join('\n')
+  }
 
   // Fix 11: DUPLICATE IMPORTS — the model sometimes imports the same identifier
   // twice (e.g. `import { Card } from './ui/card'` plus `Card,` inside another

--- a/lib/code-validator.ts
+++ b/lib/code-validator.ts
@@ -561,7 +561,10 @@ export function findUnresolvedComponents(code: string): string[] {
  * @param code - The JavaScript/JSX code to validate
  * @returns Validation result with valid flag and optional error message
  */
-export function validateJavaScriptCode(code: string): ValidationResult {
+export function validateJavaScriptCode(
+  code: string,
+  opts: { importsStripped?: boolean } = {},
+): ValidationResult {
   // First, try to auto-fix common issues (includes duplicate-import de-dupe)
   const { code: fixedCode, fixes } = autoFixCode(code)
 
@@ -584,13 +587,14 @@ export function validateJavaScriptCode(code: string): ValidationResult {
   }
 
   // Catch hallucinated components — used in JSX but never defined, imported, or
-  // in the known-available set (#76). ONLY when the code has imports: the
-  // /preview/[id] Babel renderer STRIPS all imports and injects components as
-  // globals, so on that path every component would look "unresolved" — a false
-  // positive that wrongly rejected valid apps (#91). If there are no imports,
-  // assume a globals-injection context and skip this check.
-  const hasImports = /^\s*import\s/m.test(fixedCode)
-  const unresolved = hasImports ? findUnresolvedComponents(fixedCode) : []
+  // in the known-available set (#76). The /preview/[id] Babel renderer STRIPS
+  // all imports and injects components as globals, so on THAT path every
+  // component would look "unresolved" — a false positive that wrongly rejected
+  // valid apps (#91). That caller passes importsStripped:true to skip the check.
+  // The generation path (validateGeneratedCode) does NOT strip, so it keeps full
+  // #76 coverage — a hallucinated component in import-less generated code is
+  // still flagged.
+  const unresolved = opts.importsStripped ? [] : findUnresolvedComponents(fixedCode)
   if (unresolved.length > 0) {
     const errorMessage = `Element type is invalid: <${unresolved[0]}> is used but not defined or imported`
     console.error('❌ Code validation failed (unresolved component):', unresolved.join(', '))

--- a/lib/validation-fallback.ts
+++ b/lib/validation-fallback.ts
@@ -55,7 +55,7 @@ export default function App() {
           Refining your app
         </h1>
         <p style={{ fontSize: '14px', color: '#475569', lineHeight: 1.6, margin: '0 0 20px' }}>
-          Cody generated a first version of "{'${safePrompt}'}" but it needs another
+          AINative generated a first version of "{'${safePrompt}'}" but it needs another
           pass to render cleanly. Try regenerating — the next attempt usually gets it.
         </p>
         <div style={{

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,20 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    // Only this project's own tests. Without an explicit include/exclude,
+    // vitest globs the whole tree — including leftover subagent git worktrees
+    // under .claude/worktrees/ that contain entirely different projects, which
+    // pollute the run with hundreds of unrelated (failing) tests and hang the
+    // runner on their open handles.
+    include: ['__tests__/**/*.{test,spec}.{ts,tsx}'],
+    exclude: [
+      'node_modules/**',
+      '.next/**',
+      '.claude/**',
+      'coverage/**',
+      'e2e/**', // Playwright specs run via `npm run test:e2e`, not vitest
+      'frontend/**',
+    ],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Problem

Pixel-verified re-test of the complex AINative-primitive apps showed 3 of 4 still dropped to the **"Refining your app"** validation-fallback screen (ZeroInvoice, content-feed, knowledge-graph). Only RLHF rendered. The automated Playwright tally reported all 4 "RENDERED" — a false positive (it matched elements in the outer builder chrome, not the preview iframe). Screenshots told the truth.

## Root cause (the big one)

A stray `;` was splitting multi-line method chains in generated code:

```js
const outstanding = invoices;
  .filter(inv => inv.status !== 'paid')
  .reduce((s, inv) => s + inv.total, 0)
```

Babel's `errorRecovery` parser accepts this, but Sandpack rejects it with **"Unexpected token"**, which fails validation → whole app falls back. Since `filter/map/reduce` chains are in nearly every data app, this was the **single biggest fallback cause** left after the model (Sonnet 4.5) and #91 fixes.

The `;` came from the Fix-9 semicolon-inserter (`const X = <expr>` → `const X = <expr>;`) being blind to next-line expression continuation.

## Fixes

1. **Method-chain corruption** (`lib/code-validator.ts`)
   - Fix-9 no longer appends `;` when the value continues on the next line (unbalanced parens/brackets, trailing operator/arrow, or next line starts with `.` `?` `:` `)` etc.).
   - New repair rule strips a `;` that directly precedes a `.`-continuation line, healing corruption already in source.
   - New regression suite `code-validator-method-chain.test.ts` (5 tests).

2. **#91 done properly** — replaced the blunt `hasImports` heuristic (which silently disabled #76 hallucination-detection for any import-less code) with an explicit `validateJavaScriptCode(code, { importsStripped })` option. Only the `/preview/[id]` renderer (which really strips imports) passes it; the generation path keeps full #76 coverage.

3. **ZeroDB persistence determinism** — added a concrete copy-this `/api/db` CRUD worked-example to the concise generation prompt. The same "todo that saves to a database" prompt was non-deterministically choosing `localStorage` (~50%) despite the rule forbidding it; models follow examples far better than rules.

4. **Relabel fallback** — "Cody generated" → "AINative generated" (cody is disabled; the label was misleading in logs/screenshots).

## Verification

- The 3 previously-failing persisted apps (kg/feed/invoice) now **all validate** (`valid=true`).
- **59 validator tests pass** including the new method-chain regression suite.
- Confirmed via Railway env that cody is genuinely off (`USE_CODY_AGENT=false`); the fallbacks were Claude Sonnet 4.5 output corrupted by the semicolon bug, not cody.

Live re-render verification of all complex apps follows once this deploys.