### PR TITLE
fix: guard preview against 'component object as React child' crash

### DIFF
--- a/app/api/preview/[id]/route.ts
+++ b/app/api/preview/[id]/route.ts
@@ -599,17 +599,44 @@ window.__DETECTED_COMPONENT_NAME__ = "${detectedComponentName}";
       // This works WITH React instead of fighting it
       const _originalCreateElement = React.createElement;
       let _h1Count = 0;
+      // A bare component OBJECT (forwardRef/memo/lazy — shape { $$typeof, render })
+      // placed in a CHILD position, e.g. {SomeIcon} or {chart} instead of
+      // <SomeIcon/>, makes React throw the fatal "Objects are not valid as a
+      // React child (found: object with keys {$$typeof, render})" crash overlay,
+      // killing the whole preview. This happens for Recharts/forwardRef refs the
+      // model references as values. Detect such a child and render it as an
+      // element (if it's a component) or drop it — turning a hard crash into a
+      // graceful, mostly-correct render.
+      function _sanitizeChild(c) {
+        if (c && typeof c === 'object' && c.$$typeof && c.type === undefined) {
+          // It's a component definition object, not a React element. If it's
+          // renderable (forwardRef/memo/function), mount it; else drop it.
+          try {
+            if (typeof c === 'function' || typeof c.render === 'function' || c.$$typeof) {
+              return _originalCreateElement(c, null);
+            }
+          } catch (e) {}
+          return null;
+        }
+        return c;
+      }
       React.createElement = function(type) {
+        var args = Array.prototype.slice.call(arguments);
         if (type === 'h1') {
           _h1Count++;
-          if (_h1Count > 1) {
-            // Convert extra h1 to h2 at the React level
-            var args = Array.prototype.slice.call(arguments);
-            args[0] = 'h2';
-            return _originalCreateElement.apply(React, args);
+          if (_h1Count > 1) args[0] = 'h2'; // Convert extra h1 to h2
+        }
+        // Sanitize children (args[2..]) so a stray component object can't crash.
+        if (args.length > 2) {
+          for (var _i = 2; _i < args.length; _i++) {
+            if (Array.isArray(args[_i])) {
+              args[_i] = args[_i].map(_sanitizeChild);
+            } else {
+              args[_i] = _sanitizeChild(args[_i]);
+            }
           }
         }
-        return _originalCreateElement.apply(React, arguments);
+        return _originalCreateElement.apply(React, args);
       };
 
       // Make React hooks available


### PR DESCRIPTION
## Problem

Post-#107 pixel-verification (screenshots, not the Playwright tally) confirmed the 3 target complex apps recovered — **ZeroInvoice, content-feed, and knowledge-graph all render beautifully now**. But a new chain-heavy prompt (ZeroCommerce storefront admin) surfaced a **different, pre-existing** bug: a hard React crash overlay

> Objects are not valid as a React child (found: object with keys {$$typeof, render}). If you meant to render a collection of children, use an array instead.

This is a `forwardRef`/`memo` component **object** rendered in a **child** position (e.g. `{SomeIcon}` or a Recharts ref used as a value instead of `<SomeIcon/>`). It passed validation (build "9 of 9 completed") but crashed at React render time, killing the whole preview.

## Fix

Extend the preview renderer's existing `React.createElement` interceptor to **sanitize children**: a child that is a component-definition object (`$$typeof` present, `type === undefined` — i.e. forwardRef/memo/lazy, not a valid element) is mounted as an element if renderable, otherwise dropped — turning a fatal overlay into a graceful, mostly-correct render for the whole app.

Distinguishing shapes:
- valid element → `{ $$typeof: react.element, type, props }` (has `type`) → untouched
- component def → `{ $$typeof: react.forward_ref, render }` (no `type`) → the crash source → mounted/dropped

## Verification

- `<div>{forwardRefObject}</div>` crashed before; now renders `<div><svg/></div>`.
- Regression: normal children (text, nested elements, keyed arrays, null/undefined/number/false) render unchanged.
- Route transpiles clean.

Fixes a whole class of crashes, not just this one app. Live verification of the commerce app follows on deploy.