### PR TITLE
fix(showcase): dedupe by prompt + raise the surfacing cap

### DIFF
--- a/__tests__/lib/showcase-dedupe.test.ts
+++ b/__tests__/lib/showcase-dedupe.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest'
+import {
+  combineAndDedupeShowcase,
+  normalizePromptKey,
+  type ShowcaseEntry,
+} from '@/lib/showcase-data'
+
+const entry = (o: Partial<ShowcaseEntry>): ShowcaseEntry => ({
+  slug: o.slug || 'slug',
+  title: o.title || 'Title',
+  description: '',
+  category: o.category || 'creative',
+  prompt: o.prompt || '',
+  chatId: o.chatId,
+  tags: [],
+  featured: o.featured || false,
+  createdAt: o.createdAt || '2026-07-01',
+  ...o,
+})
+
+describe('normalizePromptKey', () => {
+  it('collapses "Build a X" / "Build an X" and punctuation/case', () => {
+    const a = normalizePromptKey('Build a Todo List App!')
+    const b = normalizePromptKey('build an   todo list app')
+    // "a"/"an" stripped, lowercased, punctuation → spaces
+    expect(a).toBe('todo list app')
+    expect(b).toBe('todo list app')
+  })
+  it('is empty for empty prompt', () => {
+    expect(normalizePromptKey('')).toBe('')
+  })
+})
+
+describe('combineAndDedupeShowcase', () => {
+  it('collapses repeated prompts to the NEWEST generation', () => {
+    const dynamic = [
+      entry({ chatId: 'c1', prompt: 'Build a ZeroCommerce storefront', createdAt: '2026-07-10' }),
+      entry({ chatId: 'c2', prompt: 'Build a ZeroCommerce storefront', createdAt: '2026-07-18' }), // newest
+      entry({ chatId: 'c3', prompt: 'Build a ZeroCommerce storefront', createdAt: '2026-07-12' }),
+    ]
+    const out = combineAndDedupeShowcase([], dynamic)
+    const commerce = out.filter(e => normalizePromptKey(e.prompt) === 'zerocommerce storefront')
+    expect(commerce).toHaveLength(1)
+    expect(commerce[0].chatId).toBe('c2') // the 07-18 one
+  })
+
+  it('keeps distinct prompts', () => {
+    const dynamic = [
+      entry({ chatId: 'a', prompt: 'Build a todo app' }),
+      entry({ chatId: 'b', prompt: 'Build a kanban board' }),
+      entry({ chatId: 'c', prompt: 'Build a CRM' }),
+    ]
+    const out = combineAndDedupeShowcase([], dynamic)
+    expect(out).toHaveLength(3)
+  })
+
+  it('dedupes by chatId as well (same chatId appears once)', () => {
+    const dynamic = [
+      entry({ chatId: 'dup', prompt: 'Build a todo app', createdAt: '2026-07-10' }),
+      entry({ chatId: 'dup', prompt: 'Build a todo app', createdAt: '2026-07-10' }),
+    ]
+    expect(combineAndDedupeShowcase([], dynamic)).toHaveLength(1)
+  })
+
+  it('never drops seed entries and does not prompt-dedupe them away', () => {
+    const seed = [entry({ slug: 'seed-1', prompt: 'Build a dashboard', featured: true })]
+    const dynamic = [entry({ chatId: 'x', prompt: 'Build a dashboard' })] // same prompt as seed
+    const out = combineAndDedupeShowcase(seed, dynamic)
+    // seed kept; the dynamic dup of the same prompt is also kept because seed
+    // isn't added to the prompt-seen set — seeds are curated, dynamic collapse
+    // only applies among dynamic entries.
+    expect(out.some(e => e.slug === 'seed-1')).toBe(true)
+  })
+
+  it('does NOT merge multiple empty-prompt entries into one', () => {
+    const dynamic = [
+      entry({ chatId: 'e1', prompt: '' }),
+      entry({ chatId: 'e2', prompt: '' }),
+    ]
+    expect(combineAndDedupeShowcase([], dynamic)).toHaveLength(2)
+  })
+
+  it('sorts featured first, then newest-first', () => {
+    const seed = [entry({ slug: 'feat', prompt: 'x', featured: true, createdAt: '2026-01-01' })]
+    const dynamic = [
+      entry({ chatId: 'old', prompt: 'Build a old thing', createdAt: '2026-07-01' }),
+      entry({ chatId: 'new', prompt: 'Build a new thing', createdAt: '2026-07-19' }),
+    ]
+    const out = combineAndDedupeShowcase(seed, dynamic)
+    expect(out[0].slug).toBe('feat') // featured first despite old date
+    expect(out[1].chatId).toBe('new') // then newest dynamic
+    expect(out[2].chatId).toBe('old')
+  })
+})

--- a/app/api/showcase/route.ts
+++ b/app/api/showcase/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from 'next/server'
-import { SEED_SHOWCASE, type ShowcaseEntry, generateSlug, generateDescription } from '@/lib/showcase-data'
+import { SEED_SHOWCASE, type ShowcaseEntry, generateSlug, generateDescription, combineAndDedupeShowcase } from '@/lib/showcase-data'
 import { getDynamicShowcase, addToShowcase } from '@/lib/showcase-store'
 import { listGenerations } from '@/lib/zerodb-store'
 
@@ -9,15 +9,19 @@ import { listGenerations } from '@/lib/zerodb-store'
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url)
   const category = searchParams.get('category')
-  const limit = parseInt(searchParams.get('limit') || '50')
+  // Default page size raised so the gallery surfaces far more than the old 50;
+  // callers can still page with offset/limit. Hard-capped to avoid huge payloads.
+  const limit = Math.min(parseInt(searchParams.get('limit') || '200'), 500)
   const offset = parseInt(searchParams.get('offset') || '0')
 
-  // Load persisted entries from ZeroDB
+  // Load persisted entries from ZeroDB. Read a large window (not just the most
+  // recent 100) so older quality apps keep surfacing as the gallery grows —
+  // listGenerations caches the result, so the bigger read is paid once.
   let zerodbEntries: ShowcaseEntry[] = []
   try {
-    const rows = await listGenerations(100)
+    const rows = await listGenerations(1000)
     zerodbEntries = rows
-      .filter((r: any) => r.code_length > 1500)
+      .filter((r: any) => (r.code_length ?? (r.generated_code || '').length) > 1500)
       .map((r: any) => {
         const title = r.title || r.prompt?.replace(/^Build\s+(a|an)\s+/i, '').split(/[.!]/)[0]?.trim()?.split(' ').slice(0, 6).map((w: string) => w.charAt(0).toUpperCase() + w.slice(1)).join(' ') || 'Untitled'
         return {
@@ -37,29 +41,16 @@ export async function GET(request: NextRequest) {
     console.warn('[Showcase] ZeroDB load failed:', e)
   }
 
-  // Combine seed + in-memory + ZeroDB (deduplicate by chatId)
+  // Combine seed + in-memory + ZeroDB, dedupe by chatId AND normalized prompt
+  // (so repeated runs of the same prompt collapse to the newest), sorted
+  // featured-first then newest-first. See combineAndDedupeShowcase.
   const inMemory = getDynamicShowcase()
-  const seen = new Set<string>()
-  let all: ShowcaseEntry[] = [...SEED_SHOWCASE]
-  for (const entry of [...inMemory, ...zerodbEntries]) {
-    const key = entry.chatId || entry.slug
-    if (!seen.has(key)) {
-      seen.add(key)
-      all.push(entry)
-    }
-  }
+  let all = combineAndDedupeShowcase(SEED_SHOWCASE, [...inMemory, ...zerodbEntries])
 
   // Filter by category
   if (category) {
     all = all.filter(e => e.category === category)
   }
-
-  // Sort: featured first, then by date
-  all.sort((a, b) => {
-    if (a.featured && !b.featured) return -1
-    if (!a.featured && b.featured) return 1
-    return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-  })
 
   const total = all.length
   const entries = all.slice(offset, offset + limit)

--- a/app/showcase/showcase-client.tsx
+++ b/app/showcase/showcase-client.tsx
@@ -409,7 +409,9 @@ export function ShowcaseGalleryClient() {
   const [filter, setFilter] = useState<string | null>(null)
 
   useEffect(() => {
-    fetch('/api/showcase?offset=0&limit=100')
+    // Request a large window — the API dedupes repeated prompts server-side, so
+    // this is up to 500 DISTINCT apps, newest-first.
+    fetch('/api/showcase?offset=0&limit=500')
       .then(r => r.json())
       .then(data => {
         // Only show entries with substantial code

--- a/lib/showcase-data.ts
+++ b/lib/showcase-data.ts
@@ -171,3 +171,51 @@ export function generateSlug(title: string): string {
 export function generateDescription(prompt: string, title: string): string {
   return `${title} — AI-generated React component built with AINative Builder. ${prompt.substring(0, 120)}. Built with React, Tailwind CSS, and modern web technologies.`
 }
+
+/** Normalize a prompt so re-runs of the same request collapse to one key. */
+export function normalizePromptKey(prompt: string): string {
+  return (prompt || '')
+    .toLowerCase()
+    .replace(/^build\s+(a|an)\s+/i, '')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+}
+
+/**
+ * Combine seed + dynamic showcase entries and deduplicate.
+ *
+ * Repeated runs of the SAME prompt each get a fresh chatId, so a chatId-only
+ * dedupe leaves the gallery full of near-identical entries. This dedupes by
+ * BOTH chatId and a normalized prompt key, keeping the NEWEST generation per
+ * distinct prompt. Seed entries are always kept (curated) and are not subject
+ * to prompt-dedupe. Result is sorted featured-first, then newest-first.
+ */
+export function combineAndDedupeShowcase(
+  seed: ShowcaseEntry[],
+  dynamic: ShowcaseEntry[],
+): ShowcaseEntry[] {
+  const byDateDesc = (a: ShowcaseEntry, b: ShowcaseEntry) =>
+    new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+
+  // Sort newest-first BEFORE de-duping so the kept entry per prompt is newest.
+  const dynamicSorted = [...dynamic].sort(byDateDesc)
+  const seenChat = new Set<string>()
+  const seenPrompt = new Set<string>()
+  const out: ShowcaseEntry[] = [...seed]
+  for (const entry of dynamicSorted) {
+    const chatKey = entry.chatId || entry.slug
+    if (seenChat.has(chatKey)) continue
+    const promptKey = normalizePromptKey(entry.prompt)
+    if (promptKey && seenPrompt.has(promptKey)) continue // collapse repeats
+    seenChat.add(chatKey)
+    if (promptKey) seenPrompt.add(promptKey)
+    out.push(entry)
+  }
+
+  out.sort((a, b) => {
+    if (a.featured && !b.featured) return -1
+    if (!a.featured && b.featured) return 1
+    return byDateDesc(a, b)
+  })
+  return out
+}


### PR DESCRIPTION
## Problem

While verifying that generated apps surface in the showcase, two gaps surfaced:

1. **Duplicates** — re-running the same prompt creates a fresh `chatId` each time, so the chatId-only dedupe left the gallery full of near-identical entries (e.g. "ZeroCommerce Storefront Admin" ×3, "Knowledge Graph Explorer" ×2 from repeated test runs).

2. **Surfacing cap** — the API only read `listGenerations(100)`, so once there were >100 quality generations the **oldest silently stopped appearing** (still in ZeroDB, just not shown). At 264 today, ~164 quality apps were already below the fold.

## Fix

1. **Dedupe by prompt** — new pure `combineAndDedupeShowcase(seed, dynamic)` helper dedupes by BOTH `chatId` and a normalized prompt key, keeping the **newest** generation per distinct prompt (sorts newest-first before de-duping). Seed entries are always kept and never prompt-deduped. Empty prompts are not merged.

2. **Raise the cap** — ZeroDB read `100 → 1000` (cached via `listGenerations`, so paid once), API default page size `50 → 200` (hard-capped 500), client fetch `100 → 500` distinct apps.

## Tests

- New `__tests__/lib/showcase-dedupe.test.ts` — 8 tests: prompt-collapse-to-newest, distinct-prompts-kept, chatId dedupe, seed preservation, empty-prompt non-merge, featured+newest sort.
- Route + lib transpile clean; adjacent suites green.