### PR TITLE
fix: expose Recharts on window so charts resolve in preview (OpenCap crash)

### DIFF
--- a/app/api/preview/[id]/route.ts
+++ b/app/api/preview/[id]/route.ts
@@ -926,7 +926,31 @@ window.__DETECTED_COMPONENT_NAME__ = "${detectedComponentName}";
         Legend, ResponsiveContainer, RadialBarChart, RadialBar,
         Treemap, Funnel, FunnelChart
       } = recharts;
-      console.log('[Preview] Recharts loaded:', !!recharts.LineChart);
+      // CRITICAL: the compiled app runs in a SEPARATE global-scope <script>, so
+      // these block-scoped consts are invisible to it — using <RePieChart>,
+      // <Pie>, <ResponsiveContainer> etc. would throw "Element type is invalid:
+      // ...got undefined". Expose every Recharts component on window so the app
+      // script can resolve them. Do NOT clobber the lucide icon names already on
+      // window (PieChart/LineChart/BarChart are icons); only add the Re* aliases
+      // and the recharts-only names.
+      var _rechartsGlobals = {
+        ReLineChart: ReLineChart, ReBarChart: ReBarChart, RePieChart: RePieChart,
+        Line: Line, Bar: Bar, Pie: Pie, Cell: Cell, Area: Area, AreaChart: AreaChart,
+        RadarChart: RadarChart, Radar: Radar, PolarGrid: PolarGrid,
+        PolarAngleAxis: PolarAngleAxis, PolarRadiusAxis: PolarRadiusAxis,
+        ComposedChart: ComposedChart, Scatter: Scatter, ScatterChart: ScatterChart,
+        XAxis: XAxis, YAxis: YAxis, CartesianGrid: CartesianGrid,
+        RechartsTooltip: RechartsTooltip, Legend: Legend,
+        ResponsiveContainer: ResponsiveContainer, RadialBarChart: RadialBarChart,
+        RadialBar: RadialBar, Treemap: Treemap, Funnel: Funnel, FunnelChart: FunnelChart
+      };
+      Object.keys(_rechartsGlobals).forEach(function(k) {
+        if (_rechartsGlobals[k] && !window[k]) window[k] = _rechartsGlobals[k];
+      });
+      // Tooltip is commonly imported bare from recharts; only set it if a lucide
+      // icon named Tooltip isn't already occupying the slot.
+      if (RechartsTooltip && !window.Tooltip) window.Tooltip = RechartsTooltip;
+      console.log('[Preview] Recharts loaded:', !!recharts.LineChart, '| exposed on window:', Object.keys(_rechartsGlobals).filter(function(k){return !!window[k]}).length);
 
       // Make AIKit / AINative Primitive components available
       const aikit = window.AIKitComponents || {};


### PR DESCRIPTION
## Problem

The authoritative sweep caught the **OpenCap** app hard-crashing:
> Element type is invalid: expected a string ... but got: undefined. You likely forgot to export your component ... Check the render method of `App`.

## Root cause

The preview compiles the generated app into a **separate global-scope `<script>`** (`document.body.appendChild(_s)`). But the Recharts components were declared only as **block-scoped consts** in the setup script:
```js
const { PieChart: RePieChart, Pie, Cell, ResponsiveContainer, XAxis, ... } = recharts;
```
Those consts are invisible to the app script, so any app using the `Re*` aliases (`<RePieChart>`, `<Pie>`, `<Cell>`) resolved to `undefined` → crash.

Apps using plain names (`<LineChart>`) accidentally survived only because those names are ALSO lucide icons on `window` — so they rendered a harmless icon instead of the intended chart (wrong output, but no crash). Apps using the recharts-only aliases had no such fallback.

## Fix

Expose all Recharts components on `window` (without clobbering the lucide icon names already there — `PieChart`/`LineChart`/`BarChart` stay icons; the `Re*` aliases + `Pie`/`Cell`/`XAxis`/`ResponsiveContainer`/etc. get added). `window.Tooltip` set only if no lucide Tooltip occupies the slot.

Pairs with the graceful ErrorBoundary (#114) as a backstop for any render error this doesn't cover.

## Verification

- Root cause confirmed by comparing the crashing OpenCap app (uses `<RePieChart>`) vs the working commerce app (uses `<LineChart>` = lucide icon fallback).
- Route transpiles clean; validator-adjacent tests pass.
- Live chart-render verification follows on deploy.