### PR TITLE
fix: AIKit Sandpack stubs render icon-component props as elements (analytics crash)

### DIFF
--- a/__tests__/lib/aikit-icon-render.test.ts
+++ b/__tests__/lib/aikit-icon-render.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { aikitFiles } from '@/lib/sandpack/aikit-bundle'
+
+/**
+ * Regression: AIKit stubs (MetricCard, AIKitSidebar, EmptyState) took an `icon`
+ * prop and rendered it as a CHILD ({icon}). Apps commonly pass a component
+ * itself (icon={BarChart3}) rather than an element (icon={<BarChart3/>}); a bare
+ * component object ({ $$typeof, render }) is not a valid React child, so Sandpack
+ * crashed the whole preview with "Objects are not valid as a React child". The
+ * stubs must route icon props through a renderIcon() that mounts components as
+ * elements.
+ */
+describe('AIKit icon-prop stubs render components safely', () => {
+  const iconStubs = [
+    '/src/components/aikit/MetricCard.tsx',
+    '/src/components/aikit/AIKitSidebar.tsx',
+    '/src/components/aikit/EmptyState.tsx',
+  ]
+
+  for (const path of iconStubs) {
+    it(`${path} defines renderIcon and uses it`, () => {
+      const src = aikitFiles[path]
+      expect(src, `${path} exists`).toBeTruthy()
+      // has the guard helper
+      expect(src).toMatch(/function renderIcon/)
+      // the emitted (unescaped) code checks $$typeof correctly
+      expect(src).toMatch(/icon\.\$\$typeof/)
+      expect(src).toMatch(/React\.createElement\(icon\)/)
+    })
+  }
+
+  it('MetricCard no longer renders a raw {icon} child', () => {
+    const src = aikitFiles['/src/components/aikit/MetricCard.tsx']
+    // the icon child must go through renderIcon, not be a bare {icon}
+    expect(src).toMatch(/\{renderIcon\(icon\)\}/)
+    expect(src).not.toMatch(/text-gray-400">\{icon\}</)
+  })
+
+  it('AIKitSidebar routes item.icon through renderIcon', () => {
+    const src = aikitFiles['/src/components/aikit/AIKitSidebar.tsx']
+    expect(src).toMatch(/\{renderIcon\(item\.icon\)\}/)
+    expect(src).not.toMatch(/\{item\.icon\}\{item\.label\}/)
+  })
+
+  it('EmptyState routes icon through renderIcon', () => {
+    const src = aikitFiles['/src/components/aikit/EmptyState.tsx']
+    expect(src).toMatch(/\{renderIcon\(icon\)\}/)
+  })
+})

--- a/lib/sandpack/aikit-bundle.ts
+++ b/lib/sandpack/aikit-bundle.ts
@@ -38,13 +38,24 @@ export { AgentTimeline } from './AgentTimeline'
   '/src/components/aikit/MetricCard.tsx': `
 import React from 'react'
 interface MetricCardProps { title: string; value: string | number; change?: string; changeType?: 'positive' | 'negative' | 'neutral'; icon?: React.ReactNode; sparklineData?: number[]; className?: string }
+// Render an icon prop safely: apps often pass a component itself (icon={BarChart3})
+// instead of an element (icon={<BarChart3/>}). A bare component (function or a
+// forwardRef object { $$typeof, render }) is NOT a valid React child — rendering
+// it throws "Objects are not valid as a React child". Mount components as
+// elements; pass through valid elements/strings.
+function renderIcon(icon: any) {
+  if (!icon) return null
+  if (typeof icon === 'function') return React.createElement(icon)
+  if (typeof icon === 'object' && icon.\$\$typeof && icon.type === undefined) return React.createElement(icon)
+  return icon
+}
 export function MetricCard({ title, value, change, changeType = 'neutral', icon, sparklineData, className = '' }: MetricCardProps) {
   const changeColor = changeType === 'positive' ? 'text-green-600' : changeType === 'negative' ? 'text-red-600' : 'text-gray-500'
   return (
     <div className={\`bg-white rounded-xl border border-gray-200 p-6 \${className}\`}>
       <div className="flex items-center justify-between mb-2">
         <span className="text-sm text-gray-500">{title}</span>
-        {icon && <span className="text-gray-400">{icon}</span>}
+        {icon && <span className="text-gray-400">{renderIcon(icon)}</span>}
       </div>
       <div className="text-2xl font-bold text-gray-900">{value}</div>
       {change && <span className={\`text-sm \${changeColor}\`}>{change}</span>}
@@ -263,6 +274,12 @@ export function AIKitHeader({ title, logo, nav = [], actions, className = '' }: 
 import React from 'react'
 interface SidebarItem { label: string; icon?: React.ReactNode; active?: boolean; href?: string }
 interface AIKitSidebarProps { items: SidebarItem[]; title?: string; className?: string }
+function renderIcon(icon: any) {
+  if (!icon) return null
+  if (typeof icon === 'function') return React.createElement(icon)
+  if (typeof icon === 'object' && icon.\$\$typeof && icon.type === undefined) return React.createElement(icon)
+  return icon
+}
 export function AIKitSidebar({ items, title, className = '' }: AIKitSidebarProps) {
   return (
     <aside className={\`w-64 border-r border-gray-200 bg-white p-4 \${className}\`}>
@@ -270,7 +287,7 @@ export function AIKitSidebar({ items, title, className = '' }: AIKitSidebarProps
       <nav className="space-y-1">
         {items.map((item, i) => (
           <a key={i} href={item.href || '#'} className={\`flex items-center gap-3 px-3 py-2 rounded-lg text-sm \${item.active ? 'bg-blue-50 text-blue-700 font-medium' : 'text-gray-700 hover:bg-gray-50'}\`}>
-            {item.icon}{item.label}
+            {renderIcon(item.icon)}{item.label}
           </a>
         ))}
       </nav>
@@ -361,10 +378,16 @@ export function SkeletonCard({ className = '' }: { className?: string }) {
   '/src/components/aikit/EmptyState.tsx': `
 import React from 'react'
 interface EmptyStateProps { title?: string; description?: string; icon?: React.ReactNode; action?: React.ReactNode; className?: string }
+function renderIcon(icon: any) {
+  if (!icon) return null
+  if (typeof icon === 'function') return React.createElement(icon)
+  if (typeof icon === 'object' && icon.\$\$typeof && icon.type === undefined) return React.createElement(icon)
+  return icon
+}
 export function EmptyState({ title = 'No data', description, icon, action, className = '' }: EmptyStateProps) {
   return (
     <div className={\`flex flex-col items-center justify-center py-12 text-center \${className}\`}>
-      {icon && <div className="mb-4 text-gray-400">{icon}</div>}
+      {icon && <div className="mb-4 text-gray-400">{renderIcon(icon)}</div>}
       <h3 className="text-lg font-medium text-gray-900">{title}</h3>
       {description && <p className="mt-1 text-sm text-gray-500">{description}</p>}
       {action && <div className="mt-4">{action}</div>}


### PR DESCRIPTION
## Problem

The authoritative sweep's **analytics** crash — "Objects are not valid as a React child (found: object with keys {\$\$typeof, render})" — persisted even after #114 and #115. Root cause: **those fixes live in the `/preview/[id]` Babel path, but the PRIMARY renderer is Sandpack.** The analytics crash bubbled all the way to the Next.js `app/error.tsx` ("Something went wrong").

The real culprit is in the Sandpack AIKit stubs (`lib/sandpack/aikit-bundle.ts`). `MetricCard`, `AIKitSidebar`, and `EmptyState` rendered their `icon` prop **directly as a child**:
```jsx
{icon && <span>{icon}</span>}      // MetricCard
{item.icon}{item.label}            // AIKitSidebar
{icon && <div>{icon}</div>}        // EmptyState
```
Apps routinely pass a **component** (`icon={BarChart3}`), not an element (`icon={<BarChart3/>}`). A bare forwardRef object is not a valid React child → Sandpack crashes the whole preview.

## Fix

Add a `renderIcon()` helper to each of the 3 icon-prop stubs that mounts a component (function or `{$$typeof, render}` object) as an element via `React.createElement(icon)`, and passes valid elements/strings through unchanged.

## Verification

- Root cause traced from the analytics screenshot → `app/error.tsx` → Sandpack primary path → the `{icon}` child render in the stubs.
- Emitted Sandpack code verified to contain correct `icon.$$typeof` check (unescaped from the template).
- 6 regression tests (`aikit-icon-render.test.ts`) assert the stubs route icons through `renderIcon` and no longer emit a raw `{icon}` child.
- Live analytics re-render verification follows on deploy.