### PR TITLE
fix: allow forms/modals/popups in showcase preview iframes (interactivity)

### DIFF
--- a/app/preview/[id]/page.tsx
+++ b/app/preview/[id]/page.tsx
@@ -19,7 +19,7 @@ export default function PreviewPage() {
             src={`/api/preview/${id}`}
             className="w-full h-full border-0"
             title={`Preview ${id}`}
-            sandbox="allow-scripts allow-same-origin"
+            sandbox="allow-scripts allow-same-origin allow-forms allow-modals allow-popups"
           />
         </div>
       </div>

--- a/app/showcase/[slug]/page.tsx
+++ b/app/showcase/[slug]/page.tsx
@@ -109,7 +109,7 @@ export default async function ShowcaseDetailPage({ params }: Props) {
               className="w-full border-0"
               style={{ height: '70vh' }}
               title={`Preview of ${entry.title}`}
-              sandbox="allow-scripts allow-same-origin"
+              sandbox="allow-scripts allow-same-origin allow-forms allow-modals allow-popups"
               loading="lazy"
             />
           </div>


### PR DESCRIPTION
## Problem

User reported: form inputs, buttons, selects don't work in showcase app previews — users can't type, click, or select.

## Root cause

The showcase (`app/showcase/[slug]/page.tsx`) and standalone (`app/preview/[id]/page.tsx`) preview iframes used:
```
sandbox="allow-scripts allow-same-origin"
```
This **blocks form submission** and modal/popup interactions. Any `<form>`, and some input/dialog behaviors, are dead inside such an iframe.

## Fix

Add `allow-forms allow-modals allow-popups`:
```
sandbox="allow-scripts allow-same-origin allow-forms allow-modals allow-popups"
```
This brings the showcase/standalone previews to parity with the main builder preview-panel (which has no sandbox restriction, so its forms already work).

## Note

The component stubs themselves (Input/Select/Tabs in `lib/sandpack/`) ARE interactive — they spread `{...props}` and use context — so the sandbox attribute was the blocker for the standalone/showcase render path. Verified both edited pages transpile clean.