### PR TITLE
fix: ErrorBoundary not defined in static showcase preview HTMLs

### DIFF
--- a/public/showcase-previews/ai-chat-interface.html
+++ b/public/showcase-previews/ai-chat-interface.html
@@ -496,6 +496,8 @@
           return this.props.children;
         }
       }
+      // Fix: expose ErrorBoundary on window so the separate render script can see it (class is script-scoped).
+      window.ErrorBoundary = ErrorBoundary;
 
     </script>
     <!-- Component code: transformed by Babel.transform() synchronously, then eval'd -->
@@ -688,7 +690,8 @@ const MOCK_MESSAGES = [
           console.log('[Preview] React root created:', root);
 
           // Wrap component in ErrorBoundary to catch rendering errors
-          const wrappedElement = React.createElement(ErrorBoundary, null,
+          const _EB = (typeof window !== "undefined" && window.ErrorBoundary) ? window.ErrorBoundary : (typeof ErrorBoundary !== "undefined" ? ErrorBoundary : (function(p){ return p.children; }));
+          const wrappedElement = React.createElement(_EB, null,
             React.createElement(Component)
           );
           console.log('[Preview] React element created (wrapped in ErrorBoundary)');

--- a/public/showcase-previews/analytics-dashboard.html
+++ b/public/showcase-previews/analytics-dashboard.html
@@ -496,6 +496,8 @@
           return this.props.children;
         }
       }
+      // Fix: expose ErrorBoundary on window so the separate render script can see it (class is script-scoped).
+      window.ErrorBoundary = ErrorBoundary;
 
     </script>
     <!-- Component code: transformed by Babel.transform() synchronously, then eval'd -->
@@ -1048,7 +1050,8 @@ if (typeof window.TransactionTable === 'undefined') { window.TransactionTable = 
           console.log('[Preview] React root created:', root);
 
           // Wrap component in ErrorBoundary to catch rendering errors
-          const wrappedElement = React.createElement(ErrorBoundary, null,
+          const _EB = (typeof window !== "undefined" && window.ErrorBoundary) ? window.ErrorBoundary : (typeof ErrorBoundary !== "undefined" ? ErrorBoundary : (function(p){ return p.children; }));
+          const wrappedElement = React.createElement(_EB, null,
             React.createElement(Component)
           );
           console.log('[Preview] React element created (wrapped in ErrorBoundary)');

--- a/public/showcase-previews/blog-with-articles.html
+++ b/public/showcase-previews/blog-with-articles.html
@@ -496,6 +496,8 @@
           return this.props.children;
         }
       }
+      // Fix: expose ErrorBoundary on window so the separate render script can see it (class is script-scoped).
+      window.ErrorBoundary = ErrorBoundary;
 
     </script>
     <!-- Component code: transformed by Babel.transform() synchronously, then eval'd -->
@@ -1064,7 +1066,8 @@ if (typeof window.ArrowRight === 'undefined') { window.ArrowRight = function Arr
           console.log('[Preview] React root created:', root);
 
           // Wrap component in ErrorBoundary to catch rendering errors
-          const wrappedElement = React.createElement(ErrorBoundary, null,
+          const _EB = (typeof window !== "undefined" && window.ErrorBoundary) ? window.ErrorBoundary : (typeof ErrorBoundary !== "undefined" ? ErrorBoundary : (function(p){ return p.children; }));
+          const wrappedElement = React.createElement(_EB, null,
             React.createElement(Component)
           );
           console.log('[Preview] React element created (wrapped in ErrorBoundary)');

--- a/public/showcase-previews/ecommerce-product-page.html
+++ b/public/showcase-previews/ecommerce-product-page.html
@@ -496,6 +496,8 @@
           return this.props.children;
         }
       }
+      // Fix: expose ErrorBoundary on window so the separate render script can see it (class is script-scoped).
+      window.ErrorBoundary = ErrorBoundary;
 
     </script>
     <!-- Component code: transformed by Babel.transform() synchronously, then eval'd -->
@@ -1053,7 +1055,8 @@ if (typeof window.Zap === 'undefined') { window.Zap = function Zap(props) { retu
           console.log('[Preview] React root created:', root);
 
           // Wrap component in ErrorBoundary to catch rendering errors
-          const wrappedElement = React.createElement(ErrorBoundary, null,
+          const _EB = (typeof window !== "undefined" && window.ErrorBoundary) ? window.ErrorBoundary : (typeof ErrorBoundary !== "undefined" ? ErrorBoundary : (function(p){ return p.children; }));
+          const wrappedElement = React.createElement(_EB, null,
             React.createElement(Component)
           );
           console.log('[Preview] React element created (wrapped in ErrorBoundary)');

--- a/public/showcase-previews/kanban-task-board.html
+++ b/public/showcase-previews/kanban-task-board.html
@@ -496,6 +496,8 @@
           return this.props.children;
         }
       }
+      // Fix: expose ErrorBoundary on window so the separate render script can see it (class is script-scoped).
+      window.ErrorBoundary = ErrorBoundary;
 
     </script>
     <!-- Component code: transformed by Babel.transform() synchronously, then eval'd -->
@@ -1039,7 +1041,8 @@ if (typeof window.Calendar === 'undefined') { window.Calendar = function Calenda
           console.log('[Preview] React root created:', root);
 
           // Wrap component in ErrorBoundary to catch rendering errors
-          const wrappedElement = React.createElement(ErrorBoundary, null,
+          const _EB = (typeof window !== "undefined" && window.ErrorBoundary) ? window.ErrorBoundary : (typeof ErrorBoundary !== "undefined" ? ErrorBoundary : (function(p){ return p.children; }));
+          const wrappedElement = React.createElement(_EB, null,
             React.createElement(Component)
           );
           console.log('[Preview] React element created (wrapped in ErrorBoundary)');

--- a/public/showcase-previews/music-player.html
+++ b/public/showcase-previews/music-player.html
@@ -496,6 +496,8 @@
           return this.props.children;
         }
       }
+      // Fix: expose ErrorBoundary on window so the separate render script can see it (class is script-scoped).
+      window.ErrorBoundary = ErrorBoundary;
 
     </script>
     <!-- Component code: transformed by Babel.transform() synchronously, then eval'd -->
@@ -977,7 +979,8 @@ if (typeof window.Volume2 === 'undefined') { window.Volume2 = function Volume2(p
           console.log('[Preview] React root created:', root);
 
           // Wrap component in ErrorBoundary to catch rendering errors
-          const wrappedElement = React.createElement(ErrorBoundary, null,
+          const _EB = (typeof window !== "undefined" && window.ErrorBoundary) ? window.ErrorBoundary : (typeof ErrorBoundary !== "undefined" ? ErrorBoundary : (function(p){ return p.children; }));
+          const wrappedElement = React.createElement(_EB, null,
             React.createElement(Component)
           );
           console.log('[Preview] React element created (wrapped in ErrorBoundary)');

--- a/public/showcase-previews/saas-landing-page.html
+++ b/public/showcase-previews/saas-landing-page.html
@@ -496,6 +496,8 @@
           return this.props.children;
         }
       }
+      // Fix: expose ErrorBoundary on window so the separate render script can see it (class is script-scoped).
+      window.ErrorBoundary = ErrorBoundary;
 
     </script>
     <!-- Component code: transformed by Babel.transform() synchronously, then eval'd -->
@@ -1030,7 +1032,8 @@ if (typeof window.Check === 'undefined') { window.Check = function Check(props) 
           console.log('[Preview] React root created:', root);
 
           // Wrap component in ErrorBoundary to catch rendering errors
-          const wrappedElement = React.createElement(ErrorBoundary, null,
+          const _EB = (typeof window !== "undefined" && window.ErrorBoundary) ? window.ErrorBoundary : (typeof ErrorBoundary !== "undefined" ? ErrorBoundary : (function(p){ return p.children; }));
+          const wrappedElement = React.createElement(_EB, null,
             React.createElement(Component)
           );
           console.log('[Preview] React element created (wrapped in ErrorBoundary)');

--- a/public/showcase-previews/saas-pricing-page.html
+++ b/public/showcase-previews/saas-pricing-page.html
@@ -496,6 +496,8 @@
           return this.props.children;
         }
       }
+      // Fix: expose ErrorBoundary on window so the separate render script can see it (class is script-scoped).
+      window.ErrorBoundary = ErrorBoundary;
 
     </script>
     <!-- Component code: transformed by Babel.transform() synchronously, then eval'd -->
@@ -1068,7 +1070,8 @@ if (typeof window.Check === 'undefined') { window.Check = function Check(props) 
           console.log('[Preview] React root created:', root);
 
           // Wrap component in ErrorBoundary to catch rendering errors
-          const wrappedElement = React.createElement(ErrorBoundary, null,
+          const _EB = (typeof window !== "undefined" && window.ErrorBoundary) ? window.ErrorBoundary : (typeof ErrorBoundary !== "undefined" ? ErrorBoundary : (function(p){ return p.children; }));
+          const wrappedElement = React.createElement(_EB, null,
             React.createElement(Component)
           );
           console.log('[Preview] React element created (wrapped in ErrorBoundary)');

--- a/public/showcase-previews/team-directory.html
+++ b/public/showcase-previews/team-directory.html
@@ -496,6 +496,8 @@
           return this.props.children;
         }
       }
+      // Fix: expose ErrorBoundary on window so the separate render script can see it (class is script-scoped).
+      window.ErrorBoundary = ErrorBoundary;
 
     </script>
     <!-- Component code: transformed by Babel.transform() synchronously, then eval'd -->
@@ -978,7 +980,8 @@ if (typeof window.MapPin === 'undefined') { window.MapPin = function MapPin(prop
           console.log('[Preview] React root created:', root);
 
           // Wrap component in ErrorBoundary to catch rendering errors
-          const wrappedElement = React.createElement(ErrorBoundary, null,
+          const _EB = (typeof window !== "undefined" && window.ErrorBoundary) ? window.ErrorBoundary : (typeof ErrorBoundary !== "undefined" ? ErrorBoundary : (function(p){ return p.children; }));
+          const wrappedElement = React.createElement(_EB, null,
             React.createElement(Component)
           );
           console.log('[Preview] React element created (wrapped in ErrorBoundary)');

--- a/public/showcase-previews/weather-dashboard.html
+++ b/public/showcase-previews/weather-dashboard.html
@@ -496,6 +496,8 @@
           return this.props.children;
         }
       }
+      // Fix: expose ErrorBoundary on window so the separate render script can see it (class is script-scoped).
+      window.ErrorBoundary = ErrorBoundary;
 
     </script>
     <!-- Component code: transformed by Babel.transform() synchronously, then eval'd -->
@@ -906,7 +908,8 @@ if (typeof window.Calendar === 'undefined') { window.Calendar = function Calenda
           console.log('[Preview] React root created:', root);
 
           // Wrap component in ErrorBoundary to catch rendering errors
-          const wrappedElement = React.createElement(ErrorBoundary, null,
+          const _EB = (typeof window !== "undefined" && window.ErrorBoundary) ? window.ErrorBoundary : (typeof ErrorBoundary !== "undefined" ? ErrorBoundary : (function(p){ return p.children; }));
+          const wrappedElement = React.createElement(_EB, null,
             React.createElement(Component)
           );
           console.log('[Preview] React element created (wrapped in ErrorBoundary)');


### PR DESCRIPTION
**The real cause of the user's 'ErrorBoundary is not defined on every showcase project' report.**

#124 fixed the DYNAMIC `/api/preview/[id]` renderer, but curated showcase entries are served from **committed static snapshots** in `public/showcase-previews/*.html` (via the showcase `[slug]` page `<iframe src='/showcase-previews/{slug}.html'>`). Those 10 files were baked with the OLD renderer and have the same scope-split bug: `class ErrorBoundary` in one `<script>`, `createElement(ErrorBoundary)` in a separate global-scope `<script>` → 'ErrorBoundary is not defined'.

## Fix
Patched all 10 buggy static files: `window.ErrorBoundary = ErrorBoundary` after the class def + resolve via window with a passthrough fallback in the render script (identical to #124).

## Verified
In-browser test confirms the ErrorBoundary error is gone. (A residual blank in the *local* test is just 404s on `/vendor/*.min.js` / `/shadcn-components.js` which are served in production, not a real issue.)