### PR TITLE
fix: expose React hooks on window — fixes blank previews

### DIFF
--- a/app/api/preview/[id]/route.ts
+++ b/app/api/preview/[id]/route.ts
@@ -644,9 +644,20 @@ window.__DETECTED_COMPONENT_NAME__ = "${detectedComponentName}";
         return _originalCreateElement.apply(React, args);
       };
 
-      // Make React hooks available
+      // Make React hooks available. CRITICAL: the compiled App runs in a
+      // SEPARATE global-scope <script>, so these must be on window — a plain
+      // const here is script-scoped and the App would throw "useState is not
+      // defined" and render blank (the #1 cause of blank previews).
       const { useState, useEffect, useCallback, useMemo, useRef, useContext, createContext, Fragment } = React;
-      console.log('[Preview] React hooks loaded:', { useState, useEffect, useCallback, useMemo, useRef });
+      window.useState = useState; window.useEffect = useEffect;
+      window.useCallback = useCallback; window.useMemo = useMemo;
+      window.useRef = useRef; window.useContext = useContext;
+      window.createContext = createContext; window.Fragment = Fragment;
+      // Also expose the less-common hooks apps sometimes use.
+      window.useReducer = React.useReducer; window.useLayoutEffect = React.useLayoutEffect;
+      window.useId = React.useId; window.useTransition = React.useTransition;
+      window.useDeferredValue = React.useDeferredValue; window.useImperativeHandle = React.useImperativeHandle;
+      console.log('[Preview] React hooks loaded + exposed on window:', { useState: !!window.useState, useEffect: !!window.useEffect });
 
       // Create React components from Lucide vanilla SVG icon definitions
       // lucide (vanilla) exports icons as ["svg", {svgAttrs}, [[tag, attrs], ...]]


### PR DESCRIPTION
**THE root cause of blank previews.**

The `/api/preview/[id]` renderer destructured React hooks as `const { useState, useEffect, ... } = React` in the setup script — but the compiled App runs in a **separate global-scope script**. A `const` is script-scoped, so the App threw `ReferenceError: useState is not defined` and rendered blank. Nearly every generated app uses hooks → blank preview.

Same scope-split bug class as ErrorBoundary (#124/#125) and recharts (#115). Fix: expose all React hooks on `window`.

Diagnosed via console capture on a fresh generation: 'App compiled ✓, render called ✓, then useState is not defined → root empty'. Confirmed the app uses bare `useState()` (import stripped). Route transpiles clean.