### PR TITLE
fix: escape newline that broke preview setup script (blank previews)

### DIFF
--- a/app/api/preview/[id]/route.ts
+++ b/app/api/preview/[id]/route.ts
@@ -1067,7 +1067,7 @@ window.__DETECTED_COMPONENT_NAME__ = "${detectedComponentName}";
               React.createElement('details', { key: 'details', style: { textAlign: 'left', marginTop: '8px' } }, [
                 React.createElement('summary', { key: 'summary', style: { fontSize: '12px', color: '#94a3b8', cursor: 'pointer' } }, 'Technical details'),
                 React.createElement('pre', { key: 'stack', style: { fontSize: '11px', color: '#64748b', background: '#f1f5f9', padding: '10px', borderRadius: '8px', overflow: 'auto', marginTop: '8px' } },
-                  (this.state.error?.toString() || 'Unknown error') + '\n\n' + (this.state.errorInfo?.componentStack || '')
+                  (this.state.error?.toString() || 'Unknown error') + '\\n\\n' + (this.state.errorInfo?.componentStack || '')
                 )
               ])
             ]));


### PR DESCRIPTION
**Critical: this is why previews were blank.**

#124's ErrorBoundary fix added `+ '\n\n' +` (single backslash) inside the preview HTML *template literal*. The template converted `\n` to a real newline, so the emitted `<script>` had a literal newline inside a single-quoted string → `SyntaxError: Invalid or unexpected token` that **aborted the entire setup script**. That's why `window.useState` (from #126) and all hooks never got assigned → every hook-using app threw `useState is not defined` → blank.

Fix: escape as `'\\n\\n'`. Verified route transpiles + emitted fragment parses. Unblocks #126.