### PR TITLE
fix: lenient /preview validation (errorRecovery-parseable code renders)

### DIFF
--- a/app/api/preview/[id]/route.ts
+++ b/app/api/preview/[id]/route.ts
@@ -456,7 +456,11 @@ export async function GET(
     // Imports were stripped above (globals-injection renderer), so skip the
     // #76 unresolved-component check here — every component looks unresolved
     // once imports are gone. #91.
-    const validation = validateJavaScriptCode(componentCode, { importsStripped: true })
+    // lenient: this renderer's Babel uses errorRecovery, so it can render code
+    // that only fails the STRICT (Sandpack) parse. Don't hard-reject those here
+    // (which showed a "Code Validation Error" page for otherwise-renderable old
+    // previews) — let the errorRecovery renderer handle them.
+    const validation = validateJavaScriptCode(componentCode, { importsStripped: true, lenient: true })
     if (!validation.valid) {
       console.error('Preview validation failed for ID:', id, 'Error:', validation.error)
       const errorHtml = `

--- a/lib/code-validator.ts
+++ b/lib/code-validator.ts
@@ -607,7 +607,7 @@ export function findUnresolvedComponents(code: string): string[] {
  */
 export function validateJavaScriptCode(
   code: string,
-  opts: { importsStripped?: boolean } = {},
+  opts: { importsStripped?: boolean; lenient?: boolean } = {},
 ): ValidationResult {
   // First, try to auto-fix common issues (includes duplicate-import de-dupe)
   const { code: fixedCode, fixes } = autoFixCode(code)
@@ -694,7 +694,11 @@ export function validateJavaScriptCode(
       // tolerates, so it's explicitly excluded (builder#64).
       const isSandpackFatal =
         s.includes('unexpected token') && !s.includes('missing semicolon')
-      if (isSandpackFatal) {
+      // lenient: the /preview/[id] Babel renderer now parses with errorRecovery,
+      // so it can render code that only trips the STRICT (Sandpack) parse. Don't
+      // reject those on the preview path — the errorRecovery parse already
+      // passed, so the renderer will handle it. (Sandpack path stays strict.)
+      if (isSandpackFatal && !opts.lenient) {
         console.error('❌ Code validation failed (strict parse — Sandpack-fatal):', strictMsg)
         return {
           valid: false,


### PR DESCRIPTION
The /preview validation gate rejected code that only fails the strict Sandpack parse (showing a 'Code Validation Error' page), even though the preview's Babel now has errorRecovery and can render it. Added a `lenient` option to skip the strict-Sandpack-fatal rejection on the preview path.

Recovers strict-only-broken previews (e.g. jAKY…). The other user-reported previews (clean, b-lWRVYB, GzYvo, verify-contact) have code that fails EVEN errorRecovery — genuinely malformed old codegen that needs regeneration, not a renderer fix.