### PR TITLE
fix: silence prod console noise + /manifest.json auth-redirect

### DIFF
--- a/components/chat/preview-panel.tsx
+++ b/components/chat/preview-panel.tsx
@@ -50,24 +50,12 @@ export function PreviewPanel({
   const useSandpack = !!sandpackFiles && Object.keys(sandpackFiles).length > 0
 
 
-  // Debug: Log currentChat changes
-  React.useEffect(() => {
-    console.log('[PreviewPanel DEBUG] currentChat changed:', {
-      hasChat: !!currentChat,
-      chatId: currentChat?.id,
-      demoUrl: currentChat?.demo,
-      hasDemoUrl: !!currentChat?.demo
-    })
-  }, [currentChat])
-
   // Simulate progress based on build steps
   React.useEffect(() => {
-    console.log('[PreviewPanel] isGenerating changed:', isGenerating, 'buildSteps:', buildSteps.length)
     if (isGenerating && buildSteps.length > 0) {
       const progressPerStep = 100 / buildSteps.length
       setProgress(Math.min((buildSteps.length * progressPerStep), 95))
     } else if (!isGenerating) {
-      console.log('[PreviewPanel] Generation complete, setting progress to 100%')
       setProgress(100)
       // Reset progress after a short delay
       setTimeout(() => setProgress(0), 1000)

--- a/components/home/home-client.tsx
+++ b/components/home/home-client.tsx
@@ -177,7 +177,6 @@ export function HomeClient() {
 
   const handleSendMessage = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
-    console.log('handleSendMessage called with message:', message)
     if (!message.trim() || isLoading) return
 
     // Ensure user is authenticated (auto-create guest session if needed)
@@ -282,17 +281,11 @@ export function HomeClient() {
                     // Initialize chat ID and set preview URL immediately
                     chatId = data.chatId
                     setCurrentChatId(data.chatId)
-                    console.log('[DEBUG] Init event received:', {
-                      chatId: data.chatId,
-                      demo: data.demo,
-                      hasDemoUrl: !!data.demo
-                    })
 
                     setCurrentChat({
                       id: data.chatId,
                       demo: data.demo
                     })
-                    console.log('[DEBUG] Init: chatId + demo set')
                     break
 
                   case 'build_step':
@@ -343,18 +336,12 @@ export function HomeClient() {
                     })
 
                     // Set chat data with demo URL
-                    console.log('[DEBUG] Complete event received:', {
-                      chatId: data.chatId,
-                      demo: data.demo,
-                      hasDemoUrl: !!data.demo
-                    })
                     setCurrentChat({
                       id: data.chatId,
                       demo: data.demo  // Always set demo — preview panel handles priority
                     })
                     setCurrentChatId(data.chatId)
                     setIsLoading(false)
-                    console.log('[DEBUG] isLoading state updated to FALSE, preview URL:', data.demo)
 
                     // Force refresh the preview iframe now that content is ready
                     setRefreshKey((prev) => prev + 1)
@@ -368,7 +355,6 @@ export function HomeClient() {
 
                   case 'files':
                     // Sandpack file map from multi-file generation
-                    console.log('[DEBUG] Files event received:', Object.keys(data.files).length, 'files')
                     setSandpackFiles(data.files)
                     break
 

--- a/components/shared/chat-selector.tsx
+++ b/components/shared/chat-selector.tsx
@@ -271,11 +271,6 @@ export function ChatSelector() {
     ? chats.find((c) => c.id === currentChatId)
     : null
 
-  // Debug logging
-  console.log('[ChatSelector] Rendering with chats:', chats.length, chats)
-  console.log('[ChatSelector] Current chat ID:', currentChatId)
-  console.log('[ChatSelector] Session:', session?.user?.id)
-
   // Don't show if no chats available
   if (chats.length === 0 && !isLoading) return null
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -150,8 +150,11 @@ export const config = {
      * Match all request paths except for the ones starting with:
      * - _next/static (static files)
      * - _next/image (image optimization files)
-     * - favicon.ico, sitemap.xml, robots.txt (metadata files)
+     * - favicon.ico, sitemap.xml, robots.txt, manifest.json (metadata files)
+     * - static asset extensions (.png/.svg/.ico/.json/.webmanifest/.txt/.xml)
+     * Without these, /manifest.json got auth-redirected to /login and the
+     * browser parsed HTML as JSON → "Manifest: Line 1 Syntax error" in console.
      */
-    '/((?!_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)',
+    '/((?!_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt|manifest.json|.*\\.(?:png|jpg|jpeg|svg|gif|ico|webmanifest|txt|xml|json|css|js|woff2?)$).*)',
   ],
 }


### PR DESCRIPTION
User reported an alarming console during generation (makes it look broken when it works). Fixed: (1) /manifest.json was auth-redirected to /login → browser parsed HTML as JSON → 'Manifest: Syntax error'; excluded manifest.json + static extensions from the middleware matcher. (2) Removed noisy prod debug logs (ChatSelector render spam ~15x/gen, PreviewPanel DEBUG, home-client [DEBUG] events). Extension warnings + Tailwind-CDN/iframe-sandbox notes are not ours/expected.