### PR TITLE
fix: root OG image 502 (Satori <br/> crash)

### DIFF
--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -42,9 +42,9 @@ export default async function Image() {
 
         {/* headline */}
         <div style={{ display: 'flex', flexDirection: 'column' }}>
-          <div style={{ fontSize: 76, fontWeight: 800, color: 'white', lineHeight: 1.05, letterSpacing: -2, marginBottom: 20 }}>
-            Build React apps
-            <br />with AI in seconds
+          <div style={{ display: 'flex', flexDirection: 'column', fontSize: 76, fontWeight: 800, color: 'white', lineHeight: 1.05, letterSpacing: -2, marginBottom: 20 }}>
+            <div style={{ display: 'flex' }}>Build React apps</div>
+            <div style={{ display: 'flex' }}>with AI in seconds</div>
           </div>
           <div style={{ fontSize: 30, color: 'rgba(255,255,255,0.9)', lineHeight: 1.3, maxWidth: 900 }}>
             Production-ready, fully-interactive apps from a prompt — persistent


### PR DESCRIPTION
Root /opengraph-image returned 502 while the showcase one rendered. Cause: a <br/> between text nodes in a flex div crashes next/og's Satori. Replaced with two flex-column child divs.