### PR TITLE
Fix model dropdown (verified-live models only) + suggestion scroll button overlap

### DIFF
--- a/components/ai-elements/suggestion.tsx
+++ b/components/ai-elements/suggestion.tsx
@@ -50,51 +50,54 @@ export const Suggestions = ({
     }
   }, [children])
 
+  const scrollBy = (delta: number) => {
+    const viewport = scrollAreaRef.current?.querySelector(
+      '[data-radix-scroll-area-viewport]',
+    ) as HTMLElement
+    if (viewport) viewport.scrollBy({ left: delta, behavior: 'smooth' })
+  }
+
   return (
-    <div className="relative">
-      {/* Left fade overlay with arrow indicator */}
-      {canScrollLeft && (
-        <>
-          <div className="absolute -left-px -top-px z-10 h-[calc(100%+1px)] w-16 bg-gradient-to-r from-gray-50 dark:from-black to-transparent pointer-events-none" />
-          <div className="absolute left-2 top-1/2 -translate-y-1/2 z-20 pointer-events-none">
-            <div className="w-6 h-6 rounded-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center shadow-md">
-              <span className="text-gray-600 dark:text-gray-300 text-xs">←</span>
-            </div>
-          </div>
-        </>
-      )}
+    // Flex row: the scroller takes the available width, the scroll button lives
+    // in its own column OUTSIDE the scroll area so it never overlaps the chips.
+    <div className="flex items-center gap-2">
+      <div className="relative min-w-0 flex-1">
+        {/* Left edge: soft fade only (no floating button — keeps chips readable) */}
+        {canScrollLeft && (
+          <div className="absolute left-0 top-0 z-10 h-full w-8 bg-gradient-to-r from-gray-50 dark:from-black to-transparent pointer-events-none" />
+        )}
+        {/* Right edge: soft fade to hint there's more, no button on top of chips */}
+        {canScrollRight && (
+          <div className="absolute right-0 top-0 z-10 h-full w-8 bg-gradient-to-l from-gray-50 dark:from-black to-transparent pointer-events-none" />
+        )}
 
-      {/* Right fade overlay with clickable arrow */}
-      {canScrollRight && (
-        <>
-          <div className="absolute -right-px -top-px z-10 h-[calc(100%+1px)] w-20 bg-gradient-to-l from-gray-50 dark:from-black to-transparent pointer-events-none" />
-          <button
-            className="absolute right-1 top-1/2 -translate-y-1/2 z-20 cursor-pointer"
-            onClick={() => {
-              const viewport = scrollAreaRef.current?.querySelector('[data-radix-scroll-area-viewport]') as HTMLElement
-              if (viewport) viewport.scrollBy({ left: 200, behavior: 'smooth' })
-            }}
-            aria-label="Scroll right for more suggestions"
-          >
-            <div className="w-7 h-7 rounded-full bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 flex items-center justify-center shadow-md hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors">
-              <span className="text-gray-600 dark:text-gray-300 text-xs">→</span>
-            </div>
-          </button>
-        </>
-      )}
-
-      <ScrollArea
-        ref={scrollAreaRef}
-        className="w-full overflow-x-auto whitespace-nowrap"
-        {...props}
-      >
-        <div
-          className={cn('flex w-max flex-nowrap items-center gap-2 pr-10', className)}
+        <ScrollArea
+          ref={scrollAreaRef}
+          className="w-full overflow-x-auto whitespace-nowrap"
+          {...props}
         >
-          {children}
-        </div>
-        <ScrollBar className="hidden" orientation="horizontal" />
-      </ScrollArea>
+          <div
+            className={cn('flex w-max flex-nowrap items-center gap-2', className)}
+          >
+            {children}
+          </div>
+          <ScrollBar className="hidden" orientation="horizontal" />
+        </ScrollArea>
+      </div>
+
+      {/* Scroll-right control — outside the chip row, on the far right, no overlap */}
+      {canScrollRight && (
+        <button
+          type="button"
+          onClick={() => scrollBy(220)}
+          aria-label="Scroll right for more suggestions"
+          className="shrink-0 cursor-pointer"
+        >
+          <div className="w-8 h-8 rounded-full bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 flex items-center justify-center shadow-sm hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors">
+            <span className="text-gray-600 dark:text-gray-300 text-sm leading-none">→</span>
+          </div>
+        </button>
+      )}
     </div>
   )
 }

--- a/components/home/home-client.tsx
+++ b/components/home/home-client.tsx
@@ -58,7 +58,8 @@ export function HomeClient() {
   const [isLoading, setIsLoading] = useState(false)
   const [showChatInterface, setShowChatInterface] = useState(false)
   const [attachments, setAttachments] = useState<ImageAttachment[]>([])
-  const [selectedModel, setSelectedModel] = useState('ministral-14b')
+  // Default to a live-verified fast model — ministral-14b was 504ing (cody-builder #43)
+  const [selectedModel, setSelectedModel] = useState('deepseek-4-flash')
   const [isDragOver, setIsDragOver] = useState(false)
   const [chatHistory, setChatHistory] = useState<
     Array<{
@@ -802,20 +803,17 @@ export function HomeClient() {
                         className="appearance-none h-8 pl-2 pr-7 text-xs font-medium bg-gray-100 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg text-gray-700 dark:text-gray-300 cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors focus:outline-none focus:ring-2 focus:ring-[#5867EF]/20"
                         title="Select AI model"
                       >
+                        {/* Only models verified live on api.ainative.studio for React
+                            generation (2026-07-20). ministral-14b/qwen-coder-32b/gemma-9b/
+                            nouscoder-14b were 504/503ing and kimi-k2 silently served
+                            deepseek-4-flash — removed until fixed (cody-builder #41/#42/#43). */}
                         <optgroup label="Recommended (Fast + Reliable)">
-                          <option value="ministral-14b">Ministral 14B (Default)</option>
-                          <option value="llama-4-maverick">Llama 4 Maverick</option>
-                          <option value="llama-3.3-70b">Llama 3.3 70B</option>
-                        </optgroup>
-                        <optgroup label="High Quality (Slower)">
-                          <option value="deepseek-4-flash">DeepSeek 4 Flash</option>
-                          <option value="kimi-k2">Kimi K2</option>
+                          <option value="deepseek-4-flash">DeepSeek 4 Flash (Default)</option>
                           <option value="qwen3-coder-flash">Qwen3 Coder Flash</option>
                         </optgroup>
-                        <optgroup label="Other">
-                          <option value="qwen-coder-32b">Qwen Coder 32B</option>
-                          <option value="nouscoder-14b">NousCoder 14B</option>
-                          <option value="gemma-9b">Gemma 9B</option>
+                        <optgroup label="High Quality (Slower)">
+                          <option value="llama-3.3-70b">Llama 3.3 70B</option>
+                          <option value="llama-4-maverick">Llama 4 Maverick</option>
                           <option value="deepseek-r1-distill-qwen-7b">DeepSeek R1 Qwen 7B</option>
                         </optgroup>
                       </select>


### PR DESCRIPTION
Two fixes from live model testing + the UI overlap report.

## 1. Model dropdown — only verified-working models
Live-tested all 10 dropdown models against api.ainative.studio/v1/chat/completions (React-gen prompt):

| Model | Result | Kept? |
|-------|--------|-------|
| deepseek-4-flash | OK 1.6s | yes (new default) |
| qwen3-coder-flash | OK 1.5s | yes |
| llama-3.3-70b | OK 3.0s | yes |
| llama-4-maverick | OK 2.6s | yes |
| deepseek-r1-distill-qwen-7b | OK 6.6s | yes |
| kimi-k2 | silently served deepseek-4-flash | removed |
| ministral-14b (old default) | 504 | removed |
| qwen-coder-32b | 504 | removed |
| gemma-9b | 504 | removed |
| nouscoder-14b | 503 upstream | removed |

Default changed ministral-14b (504ing) -> deepseek-4-flash.

## 2. Suggestion scroll button overlap
Right scroll button was absolute-positioned inside the scroll area, floating over the last visible preset chip. Moved into its own flex column outside the scroller — no overlap, clean and readable. Kept a subtle edge fade as the 'more' hint.