### PR TITLE
feat(rlhf): Cody trajectory + auto-verify reward capture for fine-tuning

### DIFF
--- a/lib/agent/claude-agent.ts
+++ b/lib/agent/claude-agent.ts
@@ -14,6 +14,8 @@
  */
 
 import { spawn, type ChildProcess } from 'child_process'
+import { TrajectoryCapture } from './trajectory-capture'
+import { storeTrajectory } from './trajectory-store'
 import { createWorktree, getWorktreeFiles, getWorktreePath } from './worktree-manager'
 import {
   getAgentBinary,
@@ -260,6 +262,13 @@ export async function* runHeadlessAgent(
   let lastError: string | null = null
   let buffer = ''
 
+  // Fine-tuning trajectory capture (opt-in via CAPTURE_TRAJECTORIES=true).
+  // Taps the raw event stream; finalized + auto-verified after the run.
+  const captureEnabled = process.env.CAPTURE_TRAJECTORIES === 'true'
+  const trajectory = captureEnabled
+    ? new TrajectoryCapture(chatId, prompt, model)
+    : null
+
   const processLine = function* (line: string): Generator<AgentEvent> {
     const trimmed = line.trim()
     if (!trimmed) return
@@ -271,6 +280,9 @@ export async function* runHeadlessAgent(
       // Not valid JSON — skip
       return
     }
+
+    // Tap the raw event for fine-tuning trajectory capture (no-op if disabled).
+    trajectory?.observe(event)
 
     // Map Claude Code stream events to our SSE envelope
     yield* translateEvent(event)
@@ -424,6 +436,18 @@ export async function* runHeadlessAgent(
   })
 
   const durationMs = Date.now() - startTime
+
+  // Finalize + auto-verify + persist the trajectory for fine-tuning. Runs
+  // regardless of exit code (failed runs are valuable negative-reward signal).
+  // Fully detached: awaited errors are swallowed so capture never affects the
+  // generation result. The npm install/build in autoVerify is slow, so we do
+  // NOT block the generator on it — fire it and let it complete in background.
+  if (trajectory) {
+    void trajectory
+      .finalize(worktreePath, startTime)
+      .then((record) => storeTrajectory(record))
+      .catch((err) => console.warn('[Trajectory] capture failed:', err))
+  }
 
   if (exitCode !== 0 && !abortSignal?.aborted) {
     const errorMsg = lastError || stderr.trim() || `Agent exited with code ${exitCode}`

--- a/lib/agent/trajectory-capture.ts
+++ b/lib/agent/trajectory-capture.ts
@@ -1,0 +1,199 @@
+/**
+ * Cody trajectory capture for fine-tuning data.
+ *
+ * An agent's training signal is not `prompt -> final code`; it's the full
+ * TRAJECTORY: task -> [assistant reasoning, tool_use, tool_result, ...] ->
+ * final file tree -> an OBJECTIVE reward (does it install/build/run?).
+ *
+ * This module taps the raw stream-json events already flowing through
+ * runHeadlessAgent(), accumulates the trajectory, then on completion runs
+ * auto-verification against the worktree and persists a labeled record to
+ * ZeroDB (table: cody_trajectories). No user feedback required — the reward is
+ * execution-based (RLVR-style).
+ */
+import { spawn } from 'child_process'
+import * as fs from 'fs'
+import * as path from 'path'
+
+export interface TrajectoryStep {
+  turn: number
+  role: 'assistant' | 'tool_result'
+  text?: string
+  tool?: string
+  toolInput?: unknown
+  toolResult?: string
+}
+
+export interface VerifyResult {
+  installed: boolean | null
+  built: boolean | null
+  ran: boolean | null
+  httpOk: boolean | null
+  /** Overall objective reward: 1 if the app demonstrably works, else 0. */
+  reward: 0 | 1
+  detail: string
+}
+
+export interface TrajectoryRecord {
+  chat_id: string
+  task: string
+  model: string
+  steps: TrajectoryStep[]
+  file_tree: string[]
+  num_turns: number
+  total_cost_usd: number | null
+  duration_ms: number
+  is_error: boolean
+  verify: VerifyResult
+  created_at: string
+}
+
+/** Accumulates a single Cody run's trajectory from raw stream-json events. */
+export class TrajectoryCapture {
+  private steps: TrajectoryStep[] = []
+  private turn = 0
+  private numTurns = 0
+  private cost: number | null = null
+  private isError = false
+
+  constructor(
+    readonly chatId: string,
+    readonly task: string,
+    readonly model: string,
+  ) {}
+
+  /** Feed each raw stream-json event (called from the streaming loop). */
+  observe(event: any): void {
+    if (!event || typeof event !== 'object') return
+    if (event.type === 'assistant' && event.message?.content) {
+      this.turn++
+      for (const block of event.message.content) {
+        if (block.type === 'text' && block.text) {
+          this.steps.push({ turn: this.turn, role: 'assistant', text: String(block.text).slice(0, 8000) })
+        }
+        if (block.type === 'tool_use' && block.name) {
+          this.steps.push({
+            turn: this.turn,
+            role: 'assistant',
+            tool: block.name,
+            toolInput: truncateInput(block.input),
+          })
+        }
+      }
+    } else if (event.type === 'user' && event.message?.content) {
+      // tool_result blocks come back as user-role messages
+      for (const block of event.message.content) {
+        if (block.type === 'tool_result') {
+          const content = Array.isArray(block.content)
+            ? block.content.map((c: any) => c.text || '').join('')
+            : String(block.content || '')
+          this.steps.push({ turn: this.turn, role: 'tool_result', toolResult: content.slice(0, 4000) })
+        }
+      }
+    } else if (event.type === 'result') {
+      this.numTurns = event.num_turns ?? this.turn
+      this.cost = typeof event.total_cost_usd === 'number' ? event.total_cost_usd : null
+      this.isError = Boolean(event.is_error)
+    }
+  }
+
+  /** Finalize: snapshot the file tree, auto-verify, and return the record. */
+  async finalize(worktreePath: string, startTime: number): Promise<TrajectoryRecord> {
+    const fileTree = safeFileTree(worktreePath)
+    const verify = await autoVerify(worktreePath)
+    return {
+      chat_id: this.chatId,
+      task: this.task.slice(0, 4000),
+      model: this.model,
+      steps: this.steps,
+      file_tree: fileTree,
+      num_turns: this.numTurns,
+      total_cost_usd: this.cost,
+      duration_ms: Date.now() - startTime,
+      is_error: this.isError,
+      verify,
+      created_at: new Date().toISOString(),
+    }
+  }
+}
+
+function truncateInput(input: unknown): unknown {
+  try {
+    const s = JSON.stringify(input)
+    if (s.length <= 2000) return input
+    return { _truncated: true, preview: s.slice(0, 2000) }
+  } catch {
+    return null
+  }
+}
+
+/** List files in the worktree (excluding node_modules/.git), capped. */
+function safeFileTree(root: string): string[] {
+  const out: string[] = []
+  const walk = (dir: string, depth: number) => {
+    if (depth > 6 || out.length > 300) return
+    let entries: fs.Dirent[]
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }) } catch { return }
+    for (const e of entries) {
+      if (e.name === 'node_modules' || e.name === '.git' || e.name === '.next') continue
+      const full = path.join(dir, e.name)
+      if (e.isDirectory()) walk(full, depth + 1)
+      else out.push(path.relative(root, full))
+    }
+  }
+  walk(root, 0)
+  return out
+}
+
+/**
+ * Objective, execution-based reward. Runs the generated project and checks
+ * whether it installs, builds, and responds — no human judgment needed.
+ */
+async function autoVerify(worktreePath: string): Promise<VerifyResult> {
+  const hasPkg = fs.existsSync(path.join(worktreePath, 'package.json'))
+  if (!hasPkg) {
+    return { installed: null, built: null, ran: null, httpOk: null, reward: 0, detail: 'no package.json' }
+  }
+
+  const installed = await run('npm', ['install', '--no-audit', '--no-fund', '--loglevel=error'], worktreePath, 180_000)
+  if (!installed.ok) {
+    return { installed: false, built: null, ran: null, httpOk: null, reward: 0, detail: `install failed: ${installed.detail}` }
+  }
+
+  // Try a build if one is defined (non-fatal if absent).
+  const pkg = readJson(path.join(worktreePath, 'package.json'))
+  const scripts = (pkg?.scripts || {}) as Record<string, string>
+  let built: boolean | null = null
+  if (scripts.build) {
+    const b = await run('npm', ['run', 'build'], worktreePath, 240_000)
+    built = b.ok
+  }
+
+  // A trajectory that installs (and builds if it has a build) is a positive
+  // reward. Full run+HTTP probing is left to a deeper offline verifier since it
+  // needs port allocation; install+build is a strong, cheap signal.
+  const reward: 0 | 1 = installed.ok && built !== false ? 1 : 0
+  return {
+    installed: true,
+    built,
+    ran: null,
+    httpOk: null,
+    reward,
+    detail: reward ? 'install' + (built ? '+build ok' : ' ok') : 'build failed',
+  }
+}
+
+function readJson(p: string): any {
+  try { return JSON.parse(fs.readFileSync(p, 'utf8')) } catch { return null }
+}
+
+function run(cmd: string, args: string[], cwd: string, timeoutMs: number): Promise<{ ok: boolean; detail: string }> {
+  return new Promise((resolve) => {
+    const child = spawn(cmd, args, { cwd, stdio: ['ignore', 'pipe', 'pipe'] })
+    let err = ''
+    const timer = setTimeout(() => { child.kill('SIGKILL'); resolve({ ok: false, detail: 'timeout' }) }, timeoutMs)
+    child.stderr?.on('data', (d) => { err += d.toString().slice(0, 500) })
+    child.on('error', (e) => { clearTimeout(timer); resolve({ ok: false, detail: String(e).slice(0, 200) }) })
+    child.on('exit', (code) => { clearTimeout(timer); resolve({ ok: code === 0, detail: code === 0 ? 'ok' : err.slice(0, 200) }) })
+  })
+}

--- a/lib/agent/trajectory-store.ts
+++ b/lib/agent/trajectory-store.ts
@@ -1,0 +1,74 @@
+/**
+ * Persist Cody fine-tuning trajectories to ZeroDB (table: cody_trajectories).
+ * Mirrors the write pattern in lib/services/rlhf.service.ts. Fire-and-forget:
+ * capture must never affect the generation path.
+ */
+import { AINATIVE_API_BASE_URL } from '@/lib/constants'
+import type { TrajectoryRecord } from './trajectory-capture'
+
+const TRAJECTORY_TABLE = 'cody_trajectories'
+
+function projectId(): string {
+  return process.env.ZERODB_PROJECT_ID || '5dfbc60c-7463-4e21-ac68-9bbe536f9adf'
+}
+
+function token(): string | undefined {
+  return (
+    process.env.ZERODB_API_TOKEN ||
+    process.env.AINATIVE_API_KEY ||
+    process.env.ANTHROPIC_API_KEY
+  )
+}
+
+/** Store one labeled trajectory. Returns true on success. Never throws. */
+export async function storeTrajectory(record: TrajectoryRecord): Promise<boolean> {
+  const tok = token()
+  if (!tok) {
+    console.warn('[Trajectory] no ZeroDB token — skipping capture')
+    return false
+  }
+  try {
+    const res = await fetch(
+      `${AINATIVE_API_BASE_URL}/api/v1/projects/${projectId()}/database/tables/${TRAJECTORY_TABLE}/rows`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${tok}`,
+          'Content-Type': 'application/json',
+        },
+        // Steps/file_tree serialized so the row stays schema-flexible, matching
+        // how full_conversation is stored in rlhf_training_data.
+        body: JSON.stringify({
+          row_data: {
+            chat_id: record.chat_id,
+            task: record.task,
+            model: record.model,
+            num_turns: record.num_turns,
+            total_cost_usd: record.total_cost_usd,
+            duration_ms: record.duration_ms,
+            is_error: record.is_error,
+            reward: record.verify.reward,
+            verify_installed: record.verify.installed,
+            verify_built: record.verify.built,
+            verify_detail: record.verify.detail,
+            file_count: record.file_tree.length,
+            file_tree: JSON.stringify(record.file_tree),
+            steps: JSON.stringify(record.steps),
+            created_at: record.created_at,
+          },
+        }),
+      },
+    )
+    if (!res.ok) {
+      console.warn(`[Trajectory] store failed: HTTP ${res.status}`)
+      return false
+    }
+    console.log(
+      `[Trajectory] captured ${record.chat_id}: ${record.steps.length} steps, ${record.file_tree.length} files, reward=${record.verify.reward} (${record.verify.detail})`,
+    )
+    return true
+  } catch (err) {
+    console.warn('[Trajectory] store error:', err instanceof Error ? err.message : err)
+    return false
+  }
+}


### PR DESCRIPTION
Captures Cody's agentic trajectories (task → tool calls → file tree) with an objective execution-based reward (npm install/build) for fine-tuning. The existing RLHF tables only captured builder single-file generations, not Cody's multi-file agentic runs — this fills that gap.

- `TrajectoryCapture` taps the stream-json events already flowing through runHeadlessAgent
- `autoVerify` attaches an objective 0/1 reward (RLVR-style, no human thumbs needed)
- Persists to ZeroDB table `cody_trajectories`
- Opt-in via `CAPTURE_TRAJECTORIES=true`, fire-and-forget — never affects generation

Verified live against a real Cody run: 7 steps (Bash,Write,Write), file_tree=[package.json,server/index.js], install ok → reward=1, persisted to ZeroDB. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)