### PR TITLE
fix(agent): map cody model to an AINative-valid model (#99)

### DIFF
--- a/__tests__/lib/agent-runtime.test.ts
+++ b/__tests__/lib/agent-runtime.test.ts
@@ -5,6 +5,7 @@ import {
   getAgentSpawnEnv,
   isAgentEnabled,
   isAgentFallbackEnabled,
+  resolveAgentModel,
 } from '@/lib/agent/agent-runtime'
 
 const env = (o: Record<string, string | undefined>) => o as NodeJS.ProcessEnv
@@ -85,5 +86,37 @@ describe('agent-runtime (#79)', () => {
     it('false by default', () => {
       expect(isAgentFallbackEnabled(env({}))).toBe(false)
     })
+  })
+})
+
+describe('resolveAgentModel (builder#99 — cody model mapping)', () => {
+  it('leaves the model unchanged for the claude runtime', () => {
+    expect(resolveAgentModel('sonnet', env({}))).toBe('sonnet')
+    expect(resolveAgentModel('sonnet', env({ AGENT_RUNTIME: 'claude' }))).toBe('sonnet')
+  })
+
+  it('maps anthropic shorthands to the cody default (kimi-k2) under the cody runtime', () => {
+    const e = env({ AGENT_RUNTIME: 'cody' })
+    expect(resolveAgentModel('sonnet', e)).toBe('kimi-k2')
+    expect(resolveAgentModel('opus', e)).toBe('kimi-k2')
+    expect(resolveAgentModel('claude-sonnet', e)).toBe('kimi-k2')
+  })
+
+  it('honors CODY_MODEL override', () => {
+    const e = env({ AGENT_RUNTIME: 'cody', CODY_MODEL: 'qwen3-coder-flash' })
+    expect(resolveAgentModel('sonnet', e)).toBe('qwen3-coder-flash')
+  })
+
+  it('passes through an explicit AINative model unchanged under cody', () => {
+    const e = env({ AGENT_RUNTIME: 'cody' })
+    expect(resolveAgentModel('kimi-k2', e)).toBe('kimi-k2')
+    expect(resolveAgentModel('qwen3-coder-flash', e)).toBe('qwen3-coder-flash')
+    expect(resolveAgentModel('deepseek-4-flash', e)).toBe('deepseek-4-flash')
+  })
+
+  it('is case-insensitive on the shorthand match', () => {
+    const e = env({ AGENT_RUNTIME: 'cody' })
+    expect(resolveAgentModel('Sonnet', e)).toBe('kimi-k2')
+    expect(resolveAgentModel(' OPUS ', e)).toBe('kimi-k2')
   })
 })

--- a/lib/agent/agent-runtime.ts
+++ b/lib/agent/agent-runtime.ts
@@ -57,6 +57,35 @@ export function getAgentSpawnEnv(env: NodeJS.ProcessEnv = process.env): Record<s
 }
 
 /**
+ * Resolve the model name to pass to the agent CLI for the active runtime.
+ *
+ * The builder defaults the agent model to Claude-Code shorthands like `sonnet`
+ * / `opus`. Those work for the `claude` binary, but Cody routes to the AINative
+ * proxy, whose enterprise tier rejects `sonnet` (403 permission_error) — every
+ * such run then falls back to standard generation and NO Cody trajectory is
+ * captured. For the cody runtime we map Anthropic-family shorthands to an
+ * AINative-valid coding model (default `kimi-k2`, override via CODY_MODEL).
+ * Models already valid on AINative (e.g. `kimi-k2`, `qwen3-coder-flash`) pass
+ * through unchanged. The `claude` runtime is untouched.
+ */
+const _ANTHROPIC_SHORTHANDS = new Set([
+  'sonnet', 'opus', 'haiku',
+  'claude-sonnet', 'claude-opus', 'claude-haiku', 'claude-opus-latest',
+])
+
+export function resolveAgentModel(
+  model: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  if (getAgentRuntime(env) !== 'cody') return model
+  const codyDefault = (env.CODY_MODEL || 'kimi-k2').trim()
+  // Only remap the Anthropic-family shorthands the AINative tier can't serve;
+  // an explicit AINative model name (kimi-k2, qwen3-coder-flash, …) is honored.
+  if (_ANTHROPIC_SHORTHANDS.has(model.trim().toLowerCase())) return codyDefault
+  return model
+}
+
+/**
  * Whether the headless agent path is enabled at all. Enabled when either an
  * explicit flag is set (`USE_CLAUDE_AGENT`), or the runtime is `cody` (the
  * AINative harness is safe to use by default since it has no external cost/

--- a/lib/agent/claude-agent.ts
+++ b/lib/agent/claude-agent.ts
@@ -23,6 +23,7 @@ import {
   getAgentSpawnEnv,
   isAgentEnabled,
   isAgentFallbackEnabled,
+  resolveAgentModel,
 } from './agent-runtime'
 
 // ---------------------------------------------------------------------------
@@ -191,12 +192,18 @@ export async function* runHeadlessAgent(
 
   // 2. Build CLI arguments
   const {
-    model = DEFAULT_MODEL,
+    model: requestedModel = DEFAULT_MODEL,
     maxBudgetUsd = DEFAULT_MAX_BUDGET_USD,
     systemPrompt,
     allowedTools = DEFAULT_ALLOWED_TOOLS,
     abortSignal,
   } = options
+
+  // Map the model to one the active runtime can actually serve. For cody this
+  // rewrites Anthropic shorthands (sonnet/opus) — which the AINative tier 403s
+  // on, causing a fallback and lost capture — to an AINative coding model.
+  // Refs builder#99.
+  const model = resolveAgentModel(requestedModel)
 
   // A real codegen task is read → write → verify → fix, not 1-2 turns. With
   // maxTurns=3 the run hit --max-turns mid-tool-call and cody returned an empty


### PR DESCRIPTION
## Root cause of #99

The builder passes the Claude-Code shorthand `sonnet` as the agent model (`DEFAULT_MODEL = 'sonnet'`). That works for the `claude` binary, but **cody routes to the AINative proxy**, whose enterprise tier **rejects `sonnet` with HTTP 403** `permission_error` ("Model 'sonnet' not available for enterprise tier"). Every cody run then errors and **falls back to standard generation** — so no Cody trajectory is captured, defeating the purpose of enabling cody.

**Verified live** (right after the prod cutover): a cody generation emitted `[ERR_RATE_LIMIT]/403` → `Agent failed — falling back to standard generation` → `Generating with Claude Sonnet 4`. Direct probe of `sonnet` on the tier token: 3/3 HTTP 403. The tier's available list includes `claude-sonnet`, `kimi-k2`, `qwen3-coder-flash`, `deepseek-4-flash`, … but not the bare `sonnet`.

## Fix

`resolveAgentModel(model, env)` in `agent-runtime.ts`: under `AGENT_RUNTIME=cody` it rewrites the Anthropic-family shorthands (`sonnet`/`opus`/`haiku`/`claude-*`) to an AINative coding model — default **`kimi-k2`**, override via **`CODY_MODEL`**. Explicit AINative model names pass through unchanged; the `claude` runtime is untouched. Applied in `runHeadlessAgent` before the `--model` arg, so both the CLI and the captured trajectory record the real model.

## Tests

5 new cases: claude passthrough, shorthand→kimi-k2, `CODY_MODEL` override, explicit-model passthrough, case-insensitivity. Full agent suite green (84 tests).

## Deploy note

After merge, no env change is strictly required (default `kimi-k2`), but you can set `CODY_MODEL` to pick a different AINative coding model. This is what makes Cody trajectory capture actually accumulate real Cody runs instead of fallbacks.

Fixes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)