### PR TITLE
test: update retired Anthropic model id in integration tests

### DIFF
--- a/__tests__/README-ISSUE-11.md
+++ b/__tests__/README-ISSUE-11.md
@@ -43,7 +43,7 @@ npm run test:coverage -- __tests__/integration/prompt-generation-issue-11.test.t
 
 ```env
 ANTHROPIC_API_KEY=<your-key>
-ANTHROPIC_MODEL=claude-sonnet-4-20250514
+ANTHROPIC_MODEL=claude-sonnet-4-5-20250929
 ```
 
 ## Test Output

--- a/__tests__/README.md
+++ b/__tests__/README.md
@@ -96,7 +96,7 @@ npm run test:watch
 Required environment variables (set in `.env`):
 ```bash
 ANTHROPIC_API_KEY=<your-api-key>
-ANTHROPIC_MODEL=claude-sonnet-4-20250514
+ANTHROPIC_MODEL=claude-sonnet-4-5-20250929
 REDIS_URL=redis://localhost:6379
 ```
 

--- a/__tests__/integration/prompt-generation-issue-11.test.ts
+++ b/__tests__/integration/prompt-generation-issue-11.test.ts
@@ -86,7 +86,7 @@ describe('Custom Prompt Generation Workflow (Issue #11)', () => {
         process.env.USE_SUBAGENTS = 'false'
 
         const stream = await anthropic.messages.stream({
-          model: 'claude-sonnet-4-20250514',
+          model: process.env.ANTHROPIC_MODEL || 'claude-sonnet-4-5-20250929',
           max_tokens: 8000,
           temperature: 1,
           thinking: { type: 'enabled', budget_tokens: 2000 },

--- a/__tests__/integration/prompt-generation.test.ts
+++ b/__tests__/integration/prompt-generation.test.ts
@@ -135,7 +135,7 @@ describe('Custom Prompt Generation Workflow (Issue #11)', () => {
         try {
           // Use standard streaming with Tool Use API
           const stream = await anthropic.messages.stream({
-            model: process.env.ANTHROPIC_MODEL || 'claude-sonnet-4-20250514',
+            model: process.env.ANTHROPIC_MODEL || 'claude-sonnet-4-5-20250929',
             max_tokens: 8000,
             temperature: 1,
             thinking: {


### PR DESCRIPTION
The `prompt-generation` integration tests called the Anthropic API with the **retired** model id `claude-sonnet-4-20250514`, which 404s (`not_found_error: model: claude-sonnet-4-20250514`) — so all 20 live-LLM cases failed regardless of the code under test (verified by reproducing on a clean base branch).

The app already uses `claude-sonnet-4-5-20250929` (the chat-ws route even comments that the old id 404s). Updates both integration test files + the two test READMEs to `claude-sonnet-4-5-20250929`, gated behind the `ANTHROPIC_MODEL` env override.

Discovered while validating PR #158 — these tests were failing independently, not due to that change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)