### PR TITLE
fix(preview): share Sandpack source auto-fixes with the fallback renderer (#91)

### DIFF
--- a/app/api/preview/[id]/route.ts
+++ b/app/api/preview/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getPreview, isPreviewStreaming, storePreview, getSSRPreview } from '@/lib/preview-store'
-import { validateJavaScriptCode } from '@/lib/code-validator'
+import { validateJavaScriptCode, sanitizeForSandpack } from '@/lib/code-validator'
 // Sucrase removed — builds were failing. Using client-side Babel.
 // The key fix is using models that produce COMPLETE code (not maverick 512-tok)
 
@@ -195,6 +195,16 @@ export async function GET(
     return new NextResponse(`<!DOCTYPE html><html><body style="font-family:sans-serif;padding:20px;text-align:center"><h2>No renderable code found</h2><p>Content length: ${content.length}</p></body></html>`, {
       headers: { 'Content-Type': 'text/html' },
     })
+  }
+
+  // Apply the SAME source auto-fixes the Sandpack path uses (method-chain
+  // semicolon repair, etc.) so a codegen fix benefits BOTH renderers instead of
+  // only Sandpack. Previously this hand-rolled fallback diverged and re-broke on
+  // defects the validator already fixes elsewhere. Refs #91, #107.
+  try {
+    componentCode = sanitizeForSandpack(componentCode)
+  } catch (e) {
+    console.warn('[Preview] sanitizeForSandpack failed, using raw code:', e)
   }
 
   // CRITICAL: Detect the main component name BEFORE stripping exports


### PR DESCRIPTION
## Problem

The two preview renderers diverged on source-fixing: the **Sandpack** path runs `sanitizeForSandpack` (`autoFixCode` — method-chain semicolon repair, truncation/comment closing, etc.), but the hand-rolled `/api/preview/[id]` fallback **did not**. So a codegen fix landed in one renderer only — #107's method-chain fix helped Sandpack but not the fallback. That's the core divergence #91 calls out ("a fix in one does NOT help the other").

## Fix

Apply `sanitizeForSandpack` in the preview route before rendering (guarded so a sanitizer error falls back to raw code). Now **both renderers share one source-repair pipeline** — a fix in `code-validator` benefits both. The route already imported `validateJavaScriptCode` from the same module, so this reuses the established shared surface rather than introducing a new one.

This is the pragmatic slice of #91's acceptance ("a documented, shared, tested pipeline") — full retirement of the hand-rolled renderer depends on #89/#90 and is a larger follow-up.

## Tests

Covered by the existing code-validator suites (36 tests: method-chain + duplicates) which exercise `sanitizeForSandpack` directly. Preview route typechecks clean.

Refs #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)