### PR TITLE
fix(preview): de-dupe imports on the client Sandpack path (#161)

### DIFF
--- a/components/chat/sandpack-preview.tsx
+++ b/components/chat/sandpack-preview.tsx
@@ -9,6 +9,7 @@ import {
 import { cn } from '@/lib/utils'
 import { fixJsxErrors } from '@/lib/sandpack/jsx-fixer'
 import { getBuiltinFiles } from '@/lib/sandpack/setup'
+import { sanitizeForSandpack } from '@/lib/code-validator'
 
 class SandpackErrorBoundary extends React.Component<
   { children: React.ReactNode; className?: string },
@@ -56,10 +57,19 @@ export function SandpackPreview({ files, theme = 'light', className }: SandpackP
   // Overlay generated files on top, normalizing paths for Sandpack.
   // Sandpack's entry point is /App.tsx at the root, so we flatten /src/ paths
   // and duplicate files at multiple paths so relative imports resolve correctly.
-  for (const [path, content] of Object.entries(files)) {
+  for (const [rawPath, rawContent] of Object.entries(files)) {
+    const path = rawPath
     // Skip non-code files (robots.txt, sitemap.xml, etc.)
     if (path.endsWith('.txt') || path.endsWith('.xml') || (path.endsWith('.json') && path.includes('well-known'))) {
       continue
+    }
+    // Apply the shared source auto-fixes (duplicate-import de-dupe, method-chain
+    // repair, etc.) so the primary Sandpack path gets the SAME fixes as the
+    // /api/preview fallback (#160). A duplicate `import { useState }` otherwise
+    // crashes Sandpack with "already been declared" before render (#161).
+    let content = rawContent
+    if (/\.(t|j)sx?$/.test(path)) {
+      try { content = sanitizeForSandpack(rawContent) } catch { content = rawContent }
     }
     sandpackFiles[path] = content
 


### PR DESCRIPTION
## Problem

Generated apps intermittently crash before render with `Identifier 'useState' has already been declared` — the model emits `import React, { useState }` **plus** a second `import { useState }`.

`autoFixCode` already de-dupes this (Fix 11), and #160 wired it into the `/api/preview` fallback — but the **primary client Sandpack path** (`SandpackPreview`) never ran it, so the crash still reached users on the main render path (same divergence class as #91, on the client side).

## Fix

Apply `sanitizeForSandpack` to each generated `.ts/.tsx/.js/.jsx` file as it's overlaid into the Sandpack file set — so the client path gets the SAME duplicate-import / method-chain / truncation fixes as the fallback. Guarded so a sanitizer error falls back to raw content.

## Evidence

Caught live during the #132 interactivity pixel-verify sweep (2026-07-26): a task-manager generation crashed on exactly `import React, { useState }` + `import { useState }`. Verified `sanitizeForSandpack` collapses it to a single import (useState import count 2→1).

Covered by the existing code-validator suites (36 tests exercise `sanitizeForSandpack`, incl. the duplicate-import case).

Fixes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)