### PR TITLE
fix(preview): move dup-import de-dupe to AFTER import injection (#161)

### DIFF
--- a/components/chat/sandpack-preview.tsx
+++ b/components/chat/sandpack-preview.tsx
@@ -265,6 +265,14 @@ export function SandpackPreview({ files, theme = 'light', className }: SandpackP
       }
     }
 
+    // FINAL de-dupe pass — runs AFTER fixJsxErrors and all the React/AIKit/
+    // shadcn/lucide import injection above. A model-emitted duplicate import
+    // (`import React, { useState }` + `import { useState }`) survives the
+    // injection guards and crashes Sandpack with "already been declared" (#161).
+    // Doing this last guarantees the code Sandpack actually receives is de-duped,
+    // regardless of what earlier steps produced.
+    try { fixed = sanitizeForSandpack(fixed) } catch { /* keep fixed as-is */ }
+
     sandpackFiles[path] = fixed
     if (path === '/App.tsx') {
       console.log('[SandpackPreview] POST-FIX App.tsx:', fixed.length, 'chars,', fixed.split('\n').length, 'lines')


### PR DESCRIPTION
**Follow-up to #162 — which didn't actually fix the crash.**

#162 added `sanitizeForSandpack` in the file-overlay loop, but that runs **before** the second pass (`fixJsxErrors` + React/AIKit/shadcn/lucide import injection). A model-emitted duplicate import (`import React, { useState }` + `import { useState }`) survives the injection guards — the guard is `if (!fixed.includes("from 'react'"))`, false when a react import already exists — so the dup reached Sandpack and **still crashed** with 'Identifier useState has already been declared'.

**Reproduced live on prod after #162 deployed** (interactivity sweep, notes app — screenshot).

Fix: move the de-dupe to the **final step** of the injection loop, right before `sandpackFiles[path] = fixed`, so the code Sandpack receives is de-duped regardless of what earlier steps produced. Verified against the exact prod pipeline order (2 useState import lines → 1). 31 validator tests green.

Fixes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)