### PR TITLE
feat(plan): enforce AINative subscription rules on the builder subdomain

### DIFF
--- a/__tests__/lib/plan.test.ts
+++ b/__tests__/lib/plan.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeTier, TIER_LIMITS } from '@/lib/ainative/plan'
+
+/**
+ * Plan-tier normalization + limits must mirror core get_tier_limits so the
+ * builder enforces the SAME AINative rules (free/hobbyist: 1 workspace, 3
+ * projects) as ainative.studio.
+ */
+describe('plan tier limits (mirror of core get_tier_limits)', () => {
+  it('free/basic/starter/trial all resolve to hobbyist', () => {
+    for (const p of ['free', 'basic', 'starter', 'trial', 'Free Tier', 'HOBBYIST', '']) {
+      expect(normalizeTier(p)).toBe('hobbyist')
+    }
+  })
+
+  it('null/undefined default to hobbyist (never over-grant)', () => {
+    expect(normalizeTier(undefined)).toBe('hobbyist')
+    expect(normalizeTier(null)).toBe('hobbyist')
+  })
+
+  it('known paid tiers pass through', () => {
+    expect(normalizeTier('pro')).toBe('pro')
+    expect(normalizeTier('scale')).toBe('scale')
+    expect(normalizeTier('enterprise')).toBe('enterprise')
+  })
+
+  it('unknown tier falls back to hobbyist', () => {
+    expect(normalizeTier('made-up-plan')).toBe('hobbyist')
+  })
+
+  it('hobbyist limits match core: 1 workspace, 3 projects', () => {
+    expect(TIER_LIMITS.hobbyist).toEqual({ maxWorkspaces: 1, maxProjects: 3 })
+    expect(TIER_LIMITS.free).toEqual({ maxWorkspaces: 1, maxProjects: 3 })
+  })
+
+  it('pro has 5 workspaces + unlimited projects (-1)', () => {
+    expect(TIER_LIMITS.pro).toEqual({ maxWorkspaces: 5, maxProjects: -1 })
+  })
+
+  it('enterprise is unlimited (-1)', () => {
+    expect(TIER_LIMITS.enterprise).toEqual({ maxWorkspaces: -1, maxProjects: -1 })
+  })
+})

--- a/app/api/plan/route.ts
+++ b/app/api/plan/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server'
+import { auth } from '@/app/(auth)/auth'
+import { getPlanStatus } from '@/lib/ainative/plan'
+
+export const runtime = 'nodejs'
+
+/**
+ * GET /api/plan — the signed-in user's AINative tier + workspace/project usage.
+ * Mirrors core get_tier_limits so the builder shows the SAME plan rules as
+ * ainative.studio (free/hobbyist: 1 workspace, 3 projects). Drives remaining-
+ * slot UI and upgrade prompts. Returns hobbyist defaults for a non-AINative
+ * session so the UI degrades safely.
+ */
+export async function GET() {
+  const session = await auth()
+  const accessToken = (session as any)?.accessToken
+  if (!accessToken) {
+    return NextResponse.json(
+      {
+        tier: 'hobbyist',
+        signedIn: false,
+        workspaces: { used: 0, max: 1, remaining: 1, unlimited: false },
+        projects: { used: 0, max: 3, remaining: 3, unlimited: false },
+      },
+      { status: 200 },
+    )
+  }
+  try {
+    const status = await getPlanStatus(accessToken)
+    return NextResponse.json({ ...status, signedIn: true })
+  } catch (err) {
+    console.error('[api/plan] error:', err)
+    // Fail safe to the free tier — never over-grant limits on an error.
+    return NextResponse.json(
+      {
+        tier: 'hobbyist',
+        signedIn: true,
+        workspaces: { used: 0, max: 1, remaining: 1, unlimited: false },
+        projects: { used: 0, max: 3, remaining: 3, unlimited: false },
+      },
+      { status: 200 },
+    )
+  }
+}

--- a/app/api/workspaces/route.ts
+++ b/app/api/workspaces/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { auth } from '@/app/(auth)/auth'
 import { createWorkspace, listWorkspaces } from '@/lib/ainative/workspaces'
-import { AINativeApiError } from '@/lib/ainative/types'
+import { AINativeApiError, FREE_TIER_MAX_WORKSPACES } from '@/lib/ainative/types'
 
 export const runtime = 'nodejs'
 
@@ -42,6 +42,21 @@ export async function POST(request: Request) {
     })
     return NextResponse.json({ workspace }, { status: 201 })
   } catch (err) {
+    // Core enforces free/hobbyist max_workspaces=1 and returns 403
+    // workspace_limit_reached. Surface it as an upgrade signal (same shape as
+    // the project-limit response) rather than a raw 4xx, so the UI can prompt
+    // an upgrade instead of showing an error.
+    if (err instanceof AINativeApiError && err.status === 403) {
+      return NextResponse.json(
+        {
+          error: err.message,
+          upgradeRequired: true,
+          reason: 'free_tier_workspace_limit',
+          max: FREE_TIER_MAX_WORKSPACES,
+        },
+        { status: 403 },
+      )
+    }
     return errorResponse(err)
   }
 }

--- a/app/projects/projects-client.tsx
+++ b/app/projects/projects-client.tsx
@@ -142,9 +142,14 @@ export function ProjectsClient({ isAINative }: { isAINative: boolean }) {
             <span className="flex flex-wrap items-center gap-2">
               <Sparkles className="h-4 w-4 text-fuchsia-500" />
               You've used all {freeTier.max} free apps.
-              <Link href="/pricing" className="font-medium underline">
+              <a
+                href="https://ainative.studio/#pricing"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-medium underline"
+              >
                 Upgrade for unlimited full-stack apps →
-              </Link>
+              </a>
             </span>
           ) : (
             <span>

--- a/components/workspace-switcher.tsx
+++ b/components/workspace-switcher.tsx
@@ -8,7 +8,7 @@
  */
 import { useCallback, useEffect, useState } from 'react'
 import { useSession } from 'next-auth/react'
-import { Check, ChevronsUpDown, Building2 } from 'lucide-react'
+import { Check, ChevronsUpDown, Building2, Plus, Lock } from 'lucide-react'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -18,6 +18,12 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { Button } from '@/components/ui/button'
+
+interface PlanStatus {
+  tier: string
+  workspaces: { used: number; max: number; remaining: number; unlimited: boolean }
+  projects: { used: number; max: number; remaining: number; unlimited: boolean }
+}
 
 export interface Workspace {
   id: string
@@ -42,11 +48,12 @@ export function WorkspaceSwitcher() {
   const [workspaces, setWorkspaces] = useState<Workspace[]>([])
   const [activeId, setActiveId] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
+  const [plan, setPlan] = useState<PlanStatus | null>(null)
+  const [creating, setCreating] = useState(false)
 
   const isAINative = (session as any)?.accessToken != null
 
-  useEffect(() => {
-    if (!isAINative) return
+  const loadWorkspaces = useCallback(() => {
     let cancelled = false
     setLoading(true)
     fetch('/api/workspaces')
@@ -66,10 +73,19 @@ export function WorkspaceSwitcher() {
       })
       .catch(() => {})
       .finally(() => !cancelled && setLoading(false))
-    return () => {
-      cancelled = true
-    }
-  }, [isAINative])
+    return () => { cancelled = true }
+  }, [])
+
+  useEffect(() => {
+    if (!isAINative) return
+    const cleanup = loadWorkspaces()
+    // Plan status drives the workspace-limit UX (free = 1 workspace).
+    fetch('/api/plan').then((r) => (r.ok ? r.json() : null)).then((p) => p && setPlan(p)).catch(() => {})
+    return cleanup
+  }, [isAINative, loadWorkspaces])
+
+  const atWorkspaceLimit =
+    plan != null && !plan.workspaces.unlimited && plan.workspaces.remaining <= 0
 
   const select = useCallback((id: string) => {
     setActiveId(id)
@@ -78,6 +94,38 @@ export function WorkspaceSwitcher() {
       new CustomEvent(WORKSPACE_CHANGED_EVENT, { detail: { workspaceId: id } }),
     )
   }, [])
+
+  const createWorkspace = useCallback(async () => {
+    if (atWorkspaceLimit) {
+      window.open('https://ainative.studio/#pricing', '_blank')
+      return
+    }
+    const name = window.prompt('New workspace name')?.trim()
+    if (!name) return
+    setCreating(true)
+    try {
+      const res = await fetch('/api/workspaces', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name }),
+      })
+      const body = await res.json().catch(() => ({}))
+      if (res.ok && body.workspace?.id) {
+        loadWorkspaces()
+        select(body.workspace.id)
+      } else if (body.upgradeRequired || res.status === 403) {
+        window.alert(
+          `Your ${plan?.tier ?? 'free'} plan allows ${plan?.workspaces.max ?? 1} workspace. Upgrade to add more.`,
+        )
+        window.open('https://ainative.studio/#pricing', '_blank')
+      } else {
+        window.alert(body.error || 'Could not create workspace')
+      }
+    } finally {
+      setCreating(false)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [atWorkspaceLimit, plan, loadWorkspaces, select])
 
   if (!isAINative) return null
 
@@ -120,6 +168,41 @@ export function WorkspaceSwitcher() {
             </span>
           </DropdownMenuItem>
         ))}
+
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          onClick={createWorkspace}
+          disabled={creating}
+          className="flex items-center gap-2"
+        >
+          {atWorkspaceLimit ? (
+            <>
+              <Lock className="w-4 h-4 opacity-70" />
+              <span>Upgrade to add workspaces</span>
+            </>
+          ) : (
+            <>
+              <Plus className="w-4 h-4" />
+              <span>{creating ? 'Creating…' : 'New workspace'}</span>
+            </>
+          )}
+        </DropdownMenuItem>
+
+        {plan && (
+          <>
+            <DropdownMenuSeparator />
+            <div className="px-2 py-1.5 text-[11px] text-muted-foreground">
+              <span className="capitalize">{plan.tier}</span> plan ·{' '}
+              {plan.workspaces.unlimited
+                ? 'unlimited workspaces'
+                : `${plan.workspaces.used}/${plan.workspaces.max} workspace${plan.workspaces.max === 1 ? '' : 's'}`}
+              {' · '}
+              {plan.projects.unlimited
+                ? 'unlimited apps'
+                : `${plan.projects.used}/${plan.projects.max} apps`}
+            </div>
+          </>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   )

--- a/lib/ainative/plan.ts
+++ b/lib/ainative/plan.ts
@@ -1,0 +1,68 @@
+/**
+ * Plan / tier awareness — mirrors core's get_tier_limits so the builder
+ * subdomain shows and enforces the SAME AINative subscription rules as
+ * ainative.studio. Core is the hard gate (403 on create); this drives the UI
+ * (remaining slots, upgrade prompts) and resolves the user's real tier.
+ */
+import { ainativeFetch } from '@/lib/ainative/client'
+import { listProjects } from '@/lib/ainative/projects'
+import { listWorkspaces } from '@/lib/ainative/workspaces'
+
+/** The limits core enforces per tier (source: core get_tier_limits, project_router.py).
+ *  -1 means unlimited. Free/basic/starter/trial all resolve to hobbyist. */
+export const TIER_LIMITS: Record<string, { maxWorkspaces: number; maxProjects: number }> = {
+  hobbyist: { maxWorkspaces: 1, maxProjects: 3 },
+  free: { maxWorkspaces: 1, maxProjects: 3 },
+  pro: { maxWorkspaces: 5, maxProjects: -1 },
+  scale: { maxWorkspaces: 50, maxProjects: 50 },
+  enterprise: { maxWorkspaces: -1, maxProjects: -1 },
+}
+
+/** Normalize a core plan_name to a limits key (legacy free/basic/starter → hobbyist). */
+export function normalizeTier(planName: string | undefined | null): string {
+  const k = (planName || '').toLowerCase().trim()
+  if (['free', 'basic', 'starter', 'trial', 'free tier', 'hobbyist'].includes(k)) return 'hobbyist'
+  if (k in TIER_LIMITS) return k
+  return 'hobbyist'
+}
+
+export interface PlanStatus {
+  tier: string
+  workspaces: { used: number; max: number; remaining: number; unlimited: boolean }
+  projects: { used: number; max: number; remaining: number; unlimited: boolean }
+}
+
+/** Fetch the user's current tier + usage in one shot. */
+export async function getPlanStatus(accessToken: string): Promise<PlanStatus> {
+  // Resolve tier from the subscription endpoint; fall back to hobbyist (the
+  // free/default tier) if it's missing so we never over-grant.
+  let tier = 'hobbyist'
+  try {
+    const sub = await ainativeFetch<any>('/api/v1/subscription', accessToken)
+    const planName = sub?.data?.plan_name ?? sub?.plan_name ?? sub?.data?.plan ?? null
+    tier = normalizeTier(planName)
+  } catch {
+    tier = 'hobbyist'
+  }
+
+  const limits = TIER_LIMITS[tier] ?? TIER_LIMITS.hobbyist
+
+  // Current usage — count the user's real workspaces + projects.
+  const [workspaces, projects] = await Promise.all([
+    listWorkspaces(accessToken).catch(() => []),
+    listProjects(accessToken).catch(() => []),
+  ])
+
+  const slot = (used: number, max: number) => ({
+    used,
+    max,
+    unlimited: max === -1,
+    remaining: max === -1 ? Infinity : Math.max(0, max - used),
+  })
+
+  return {
+    tier,
+    workspaces: slot(workspaces.length, limits.maxWorkspaces),
+    projects: slot(projects.length, limits.maxProjects),
+  }
+}

--- a/lib/ainative/types.ts
+++ b/lib/ainative/types.ts
@@ -78,8 +78,12 @@ export interface ProjectCreateInput {
   organization_id?: string
 }
 
-/** Free-tier project cap enforced by core (get_tier_limits: free => 3). */
+/** Free-tier caps enforced platform-wide by core get_tier_limits (hobbyist:
+ *  max_workspaces=1, max_projects=3). The builder subdomain mirrors these so a
+ *  free user gets the SAME limits as on ainative.studio. Core is the hard
+ *  gate (403 on create); the builder surfaces them as upgrade prompts. */
 export const FREE_TIER_MAX_PROJECTS = 3
+export const FREE_TIER_MAX_WORKSPACES = 1
 
 export class AINativeApiError extends Error {
   constructor(


### PR DESCRIPTION
Builder is a subdomain of the **same auth system + subscription plans** as ainative.studio, so it must enforce the **same plan rules**. This wires that up.

## Source of truth (core)
Core `get_tier_limits` (project_router.py) is the hard gate — free/hobbyist = **1 workspace, 3 projects** — and returns **403** on create (`workspace_limit_reached` / project limit). The builder's workspace/project routes already call those enforcing core endpoints **with the user's real access token** (not the sk_ agent key).

## What this adds
- **Workspace-limit 403 surfacing** in `/api/workspaces` (`upgradeRequired` + `free_tier_workspace_limit`), mirroring the existing project handling. `FREE_TIER_MAX_WORKSPACES=1`.
- **`lib/ainative/plan.ts`** — `TIER_LIMITS` mirrored from core, `normalizeTier` (free/basic/starter/trial → hobbyist), `getPlanStatus` (resolves the user's real tier from `/api/v1/subscription` + counts actual usage; **fails safe to hobbyist** so we never over-grant).
- **`GET /api/plan`** — tier + remaining workspace/project slots.
- **Workspace switcher UI** — shows `<tier> plan · N/1 workspace · N/3 apps`, a **gated 'New workspace'** action (creates under limit; 'Upgrade to add workspaces' at the cap → canonical pricing).
- Project-limit UX already existed (projects page + generation flow show the upgrade prompt); pointed its CTA at `https://ainative.studio/#pricing`.

## Onboarding
Default workspace is already ensured at login (`resolveDefaultWorkspace` → core `get_or_create_default_workspace`), so first-run users always have one.

## Tests
7 tests: tier normalization + limits match core exactly. Types clean under project tsconfig (pre-existing unrelated test-file TS errors aside).

Note: verifies the SAME free=1-workspace / free=3-projects rules enforced on ainative.studio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)