### PR TITLE
fix(plan): correct free→Hobbyist tier + add 7-day trial state

### DIFF
--- a/__tests__/lib/plan.test.ts
+++ b/__tests__/lib/plan.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { normalizeTier, TIER_LIMITS } from '@/lib/ainative/plan'
+import { normalizeTier, TIER_LIMITS, tierLabel } from '@/lib/ainative/plan'
 
 /**
  * Plan-tier normalization + limits must mirror core get_tier_limits so the
@@ -30,7 +30,10 @@ describe('plan tier limits (mirror of core get_tier_limits)', () => {
 
   it('hobbyist limits match core: 1 workspace, 3 projects', () => {
     expect(TIER_LIMITS.hobbyist).toEqual({ maxWorkspaces: 1, maxProjects: 3 })
-    expect(TIER_LIMITS.free).toEqual({ maxWorkspaces: 1, maxProjects: 3 })
+    // 'free' is retired — there is no TIER_LIMITS.free; legacy 'free' normalizes
+    // to hobbyist on the way in.
+    expect(TIER_LIMITS.free).toBeUndefined()
+    expect(normalizeTier('free')).toBe('hobbyist')
   })
 
   it('pro has 5 workspaces + unlimited projects (-1)', () => {
@@ -39,5 +42,13 @@ describe('plan tier limits (mirror of core get_tier_limits)', () => {
 
   it('enterprise is unlimited (-1)', () => {
     expect(TIER_LIMITS.enterprise).toEqual({ maxWorkspaces: -1, maxProjects: -1 })
+  })
+
+  it('tierLabel is customer-facing (Hobbyist, not free)', () => {
+    expect(tierLabel('hobbyist')).toBe('Hobbyist')
+    expect(tierLabel('pro')).toBe('Pro')
+    expect(tierLabel('enterprise')).toBe('Enterprise')
+    // unknown/legacy → Hobbyist, never 'free'
+    expect(tierLabel('free')).toBe('Hobbyist')
   })
 })

--- a/app/api/plan/route.ts
+++ b/app/api/plan/route.ts
@@ -4,41 +4,35 @@ import { getPlanStatus } from '@/lib/ainative/plan'
 
 export const runtime = 'nodejs'
 
+/** Safe default: a trialing Hobbyist (the entry tier that replaced free) with
+ *  its 1-workspace / 3-project limits. Used when there's no session or on
+ *  error, so the UI degrades safely and we never over-grant. */
+const HOBBYIST_DEFAULT = {
+  tier: 'hobbyist',
+  tierLabel: 'Hobbyist',
+  status: 'trialing' as const,
+  trial: { active: true, endsAt: null, daysLeft: null },
+  workspaces: { used: 0, max: 1, remaining: 1, unlimited: false },
+  projects: { used: 0, max: 3, remaining: 3, unlimited: false },
+}
+
 /**
- * GET /api/plan — the signed-in user's AINative tier + workspace/project usage.
- * Mirrors core get_tier_limits so the builder shows the SAME plan rules as
- * ainative.studio (free/hobbyist: 1 workspace, 3 projects). Drives remaining-
- * slot UI and upgrade prompts. Returns hobbyist defaults for a non-AINative
- * session so the UI degrades safely.
+ * GET /api/plan — the signed-in user's AINative tier, trial state, and
+ * workspace/project usage. Mirrors core get_tier_limits so the builder shows
+ * the SAME plan rules as ainative.studio (Hobbyist: 1 workspace, 3 projects,
+ * 7-day trial). Drives remaining-slot UI, trial countdown, and upgrade prompts.
  */
 export async function GET() {
   const session = await auth()
   const accessToken = (session as any)?.accessToken
   if (!accessToken) {
-    return NextResponse.json(
-      {
-        tier: 'hobbyist',
-        signedIn: false,
-        workspaces: { used: 0, max: 1, remaining: 1, unlimited: false },
-        projects: { used: 0, max: 3, remaining: 3, unlimited: false },
-      },
-      { status: 200 },
-    )
+    return NextResponse.json({ ...HOBBYIST_DEFAULT, signedIn: false }, { status: 200 })
   }
   try {
     const status = await getPlanStatus(accessToken)
     return NextResponse.json({ ...status, signedIn: true })
   } catch (err) {
     console.error('[api/plan] error:', err)
-    // Fail safe to the free tier — never over-grant limits on an error.
-    return NextResponse.json(
-      {
-        tier: 'hobbyist',
-        signedIn: true,
-        workspaces: { used: 0, max: 1, remaining: 1, unlimited: false },
-        projects: { used: 0, max: 3, remaining: 3, unlimited: false },
-      },
-      { status: 200 },
-    )
+    return NextResponse.json({ ...HOBBYIST_DEFAULT, signedIn: true }, { status: 200 })
   }
 }

--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -6,7 +6,7 @@ import {
   listProjects,
   listProjectsForWorkspace,
 } from '@/lib/ainative/projects'
-import { AINativeApiError, FREE_TIER_MAX_PROJECTS } from '@/lib/ainative/types'
+import { AINativeApiError, HOBBYIST_MAX_PROJECTS } from '@/lib/ainative/types'
 
 export const runtime = 'nodejs'
 
@@ -25,13 +25,13 @@ export async function GET(request: Request) {
     const projects = workspaceId
       ? await listProjectsForWorkspace(accessToken, workspaceId)
       : await listProjects(accessToken)
-    return NextResponse.json({
-      projects,
-      freeTier: {
-        max: FREE_TIER_MAX_PROJECTS,
-        remaining: freeTierProjectsRemaining(projects.length),
-      },
-    })
+    const tierUsage = {
+      max: HOBBYIST_MAX_PROJECTS,
+      remaining: freeTierProjectsRemaining(projects.length),
+    }
+    // `tierUsage` is the current field; `freeTier` retained temporarily for
+    // backward compatibility with any client still reading the old key.
+    return NextResponse.json({ projects, tierUsage, freeTier: tierUsage })
   } catch (err) {
     return errorResponse(err)
   }
@@ -63,14 +63,14 @@ export async function POST(request: Request) {
     })
     return NextResponse.json({ project }, { status: 201 })
   } catch (err) {
-    // Surface the free-tier cap as an upgrade signal rather than a raw 4xx.
+    // Surface the Hobbyist project cap as an upgrade signal rather than a raw 4xx.
     if (err instanceof AINativeApiError && err.status === 403) {
       return NextResponse.json(
         {
           error: err.message,
           upgradeRequired: true,
-          reason: 'free_tier_project_limit',
-          max: FREE_TIER_MAX_PROJECTS,
+          reason: 'project_limit_reached',
+          max: HOBBYIST_MAX_PROJECTS,
         },
         { status: 403 },
       )

--- a/app/api/workspaces/route.ts
+++ b/app/api/workspaces/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { auth } from '@/app/(auth)/auth'
 import { createWorkspace, listWorkspaces } from '@/lib/ainative/workspaces'
-import { AINativeApiError, FREE_TIER_MAX_WORKSPACES } from '@/lib/ainative/types'
+import { AINativeApiError, HOBBYIST_MAX_WORKSPACES } from '@/lib/ainative/types'
 
 export const runtime = 'nodejs'
 
@@ -42,7 +42,7 @@ export async function POST(request: Request) {
     })
     return NextResponse.json({ workspace }, { status: 201 })
   } catch (err) {
-    // Core enforces free/hobbyist max_workspaces=1 and returns 403
+    // Core enforces Hobbyist max_workspaces=1 and returns 403
     // workspace_limit_reached. Surface it as an upgrade signal (same shape as
     // the project-limit response) rather than a raw 4xx, so the UI can prompt
     // an upgrade instead of showing an error.
@@ -51,8 +51,8 @@ export async function POST(request: Request) {
         {
           error: err.message,
           upgradeRequired: true,
-          reason: 'free_tier_workspace_limit',
-          max: FREE_TIER_MAX_WORKSPACES,
+          reason: 'workspace_limit_reached',
+          max: HOBBYIST_MAX_WORKSPACES,
         },
         { status: 403 },
       )

--- a/app/projects/projects-client.tsx
+++ b/app/projects/projects-client.tsx
@@ -19,14 +19,14 @@ interface Project {
   created_at: string
 }
 
-interface FreeTier {
+interface TierUsage {
   max: number
   remaining: number
 }
 
 export function ProjectsClient({ isAINative }: { isAINative: boolean }) {
   const [projects, setProjects] = useState<Project[]>([])
-  const [freeTier, setFreeTier] = useState<FreeTier | null>(null)
+  const [tierUsage, setTierUsage] = useState<TierUsage | null>(null)
   const [loading, setLoading] = useState(true)
   const [creating, setCreating] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -44,7 +44,7 @@ export function ProjectsClient({ isAINative }: { isAINative: boolean }) {
       }
       const data = await res.json()
       setProjects(data.projects ?? [])
-      setFreeTier(data.freeTier ?? null)
+      setTierUsage(data.tierUsage ?? data.freeTier ?? null)
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to load projects')
     } finally {
@@ -85,7 +85,7 @@ export function ProjectsClient({ isAINative }: { isAINative: boolean }) {
       if (!res.ok) {
         if (body.upgradeRequired) {
           setError(
-            `You've reached the free-tier limit of ${body.max} apps. Upgrade to build unlimited full-stack apps.`,
+            `You've reached your plan limit of ${body.max} apps. Upgrade to build unlimited full-stack apps.`,
           )
           return
         }
@@ -115,7 +115,7 @@ export function ProjectsClient({ isAINative }: { isAINative: boolean }) {
     )
   }
 
-  const atLimit = freeTier != null && freeTier.remaining <= 0
+  const atLimit = tierUsage != null && tierUsage.remaining <= 0
 
   return (
     <div className="mx-auto max-w-5xl px-6 py-10">
@@ -136,12 +136,12 @@ export function ProjectsClient({ isAINative }: { isAINative: boolean }) {
         </Button>
       </div>
 
-      {freeTier && (
+      {tierUsage && (
         <div className="mb-6 rounded-lg border border-border bg-muted/40 px-4 py-3 text-sm">
           {atLimit ? (
             <span className="flex flex-wrap items-center gap-2">
               <Sparkles className="h-4 w-4 text-fuchsia-500" />
-              You've used all {freeTier.max} free apps.
+              You've used all {tierUsage.max} apps on your plan.
               <a
                 href="https://ainative.studio/#pricing"
                 target="_blank"
@@ -153,8 +153,8 @@ export function ProjectsClient({ isAINative }: { isAINative: boolean }) {
             </span>
           ) : (
             <span>
-              Free tier: <strong>{freeTier.remaining}</strong> of{' '}
-              <strong>{freeTier.max}</strong> apps remaining.
+              Hobbyist plan: <strong>{tierUsage.remaining}</strong> of{' '}
+              <strong>{tierUsage.max}</strong> apps remaining.
             </span>
           )}
         </div>

--- a/components/home/home-client.tsx
+++ b/components/home/home-client.tsx
@@ -410,7 +410,7 @@ export function HomeClient() {
                               ...prev,
                               {
                                 type: 'assistant',
-                                content: `You've reached the free-tier limit of ${result.max ?? 3} apps. Upgrade to build unlimited full-stack apps with AINative primitives.`,
+                                content: `You've reached your plan limit of ${result.max ?? 3} apps. Upgrade to build unlimited full-stack apps with AINative primitives.`,
                               },
                             ])
                           }

--- a/components/upgrade-banner.tsx
+++ b/components/upgrade-banner.tsx
@@ -26,11 +26,11 @@ export function UpgradeBanner({ type, tokensUsed, tokenLimit, onDismiss }: Upgra
           </div>
         </div>
         <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
-          Free Plan Limit Reached
+          Plan Limit Reached
         </h3>
         <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
-          You've used all your free tokens this month. Upgrade to Pro for 1M tokens/month
-          and access to Claude Sonnet 4 — the most capable AI model for code generation.
+          You've used all your tokens this month on the Hobbyist plan. Upgrade to Pro for 1M
+          tokens/month and access to Claude Sonnet 4 — the most capable AI model for code generation.
         </p>
         <div className="flex items-center justify-center gap-3">
           <Button
@@ -61,7 +61,7 @@ export function UpgradeBanner({ type, tokensUsed, tokenLimit, onDismiss }: Upgra
           <Zap className="h-4 w-4 text-amber-500 flex-shrink-0" />
           <div>
             <p className="text-sm text-gray-700 dark:text-gray-300">
-              <span className="font-medium">{usagePercent}% of free tokens used</span>
+              <span className="font-medium">{usagePercent}% of your monthly tokens used</span>
               {' '}({tokensUsed?.toLocaleString()}/{tokenLimit?.toLocaleString()})
             </p>
           </div>

--- a/components/workspace-switcher.tsx
+++ b/components/workspace-switcher.tsx
@@ -21,6 +21,9 @@ import { Button } from '@/components/ui/button'
 
 interface PlanStatus {
   tier: string
+  tierLabel: string
+  status: 'trialing' | 'active' | 'none'
+  trial: { active: boolean; endsAt: string | null; daysLeft: number | null }
   workspaces: { used: number; max: number; remaining: number; unlimited: boolean }
   projects: { used: number; max: number; remaining: number; unlimited: boolean }
 }
@@ -115,7 +118,7 @@ export function WorkspaceSwitcher() {
         select(body.workspace.id)
       } else if (body.upgradeRequired || res.status === 403) {
         window.alert(
-          `Your ${plan?.tier ?? 'free'} plan allows ${plan?.workspaces.max ?? 1} workspace. Upgrade to add more.`,
+          `Your ${plan?.tierLabel ?? 'Hobbyist'} plan includes ${plan?.workspaces.max ?? 1} workspace. Upgrade to add more.`,
         )
         window.open('https://ainative.studio/#pricing', '_blank')
       } else {
@@ -192,14 +195,21 @@ export function WorkspaceSwitcher() {
           <>
             <DropdownMenuSeparator />
             <div className="px-2 py-1.5 text-[11px] text-muted-foreground">
-              <span className="capitalize">{plan.tier}</span> plan ·{' '}
-              {plan.workspaces.unlimited
-                ? 'unlimited workspaces'
-                : `${plan.workspaces.used}/${plan.workspaces.max} workspace${plan.workspaces.max === 1 ? '' : 's'}`}
-              {' · '}
-              {plan.projects.unlimited
-                ? 'unlimited apps'
-                : `${plan.projects.used}/${plan.projects.max} apps`}
+              <span className="font-medium text-foreground">{plan.tierLabel}</span>
+              {plan.trial.active && (
+                <span className="ml-1 text-amber-600 dark:text-amber-400">
+                  · Trial{plan.trial.daysLeft != null ? ` · ${plan.trial.daysLeft}d left` : ''}
+                </span>
+              )}
+              <div className="mt-0.5">
+                {plan.workspaces.unlimited
+                  ? 'unlimited workspaces'
+                  : `${plan.workspaces.used}/${plan.workspaces.max} workspace${plan.workspaces.max === 1 ? '' : 's'}`}
+                {' · '}
+                {plan.projects.unlimited
+                  ? 'unlimited apps'
+                  : `${plan.projects.used}/${plan.projects.max} apps`}
+              </div>
             </div>
           </>
         )}

--- a/lib/ainative/link-project.ts
+++ b/lib/ainative/link-project.ts
@@ -5,7 +5,7 @@
  *
  * Fire-and-forget by design — a project-linking failure must never break the
  * generation UX. Returns the created project id, or a structured result when
- * the free-tier cap is hit so the caller can prompt an upgrade.
+ * the Hobbyist project cap is hit so the caller can prompt an upgrade.
  */
 import { getActiveWorkspaceId } from '@/components/workspace-switcher'
 

--- a/lib/ainative/plan.ts
+++ b/lib/ainative/plan.ts
@@ -2,23 +2,39 @@
  * Plan / tier awareness — mirrors core's get_tier_limits so the builder
  * subdomain shows and enforces the SAME AINative subscription rules as
  * ainative.studio. Core is the hard gate (403 on create); this drives the UI
- * (remaining slots, upgrade prompts) and resolves the user's real tier.
+ * (remaining slots, trial state, upgrade prompts) and resolves the user's tier.
+ *
+ * There is NO "free" tier anymore — Hobbyist ($5, 7-day trial) is the entry
+ * tier that replaced it (core #128). New users start on Hobbyist with
+ * status="trialing"; legacy plan names (free/basic/starter) still resolve to
+ * hobbyist on the way in, but the customer-facing tier is Hobbyist.
  */
 import { ainativeFetch } from '@/lib/ainative/client'
 import { listProjects } from '@/lib/ainative/projects'
 import { listWorkspaces } from '@/lib/ainative/workspaces'
 
 /** The limits core enforces per tier (source: core get_tier_limits, project_router.py).
- *  -1 means unlimited. Free/basic/starter/trial all resolve to hobbyist. */
+ *  -1 means unlimited. */
 export const TIER_LIMITS: Record<string, { maxWorkspaces: number; maxProjects: number }> = {
   hobbyist: { maxWorkspaces: 1, maxProjects: 3 },
-  free: { maxWorkspaces: 1, maxProjects: 3 },
   pro: { maxWorkspaces: 5, maxProjects: -1 },
   scale: { maxWorkspaces: 50, maxProjects: 50 },
   enterprise: { maxWorkspaces: -1, maxProjects: -1 },
 }
 
-/** Normalize a core plan_name to a limits key (legacy free/basic/starter → hobbyist). */
+/** Human label for a tier key (customer-facing). */
+export function tierLabel(tier: string): string {
+  const map: Record<string, string> = {
+    hobbyist: 'Hobbyist',
+    pro: 'Pro',
+    scale: 'Scale',
+    enterprise: 'Enterprise',
+  }
+  return map[tier] ?? 'Hobbyist'
+}
+
+/** Normalize a core plan_name to a limits key. Legacy free/basic/starter/trial
+ *  all resolve to hobbyist (the entry tier that replaced free). */
 export function normalizeTier(planName: string | undefined | null): string {
   const k = (planName || '').toLowerCase().trim()
   if (['free', 'basic', 'starter', 'trial', 'free tier', 'hobbyist'].includes(k)) return 'hobbyist'
@@ -28,24 +44,47 @@ export function normalizeTier(planName: string | undefined | null): string {
 
 export interface PlanStatus {
   tier: string
+  tierLabel: string
+  /** Subscription status from core: 'trialing' | 'active' | 'none'. */
+  status: 'trialing' | 'active' | 'none'
+  trial: { active: boolean; endsAt: string | null; daysLeft: number | null }
   workspaces: { used: number; max: number; remaining: number; unlimited: boolean }
   projects: { used: number; max: number; remaining: number; unlimited: boolean }
 }
 
-/** Fetch the user's current tier + usage in one shot. */
+function daysUntil(iso: string | null): number | null {
+  if (!iso) return null
+  const end = Date.parse(iso)
+  if (Number.isNaN(end)) return null
+  return Math.max(0, Math.ceil((end - Date.now()) / 86_400_000))
+}
+
+/** Fetch the user's current tier, trial state, and usage in one shot. */
 export async function getPlanStatus(accessToken: string): Promise<PlanStatus> {
-  // Resolve tier from the subscription endpoint; fall back to hobbyist (the
-  // free/default tier) if it's missing so we never over-grant.
+  // Resolve tier + trial from the subscription endpoint. Core returns
+  // { data: { subscription: { status, trial_end, plan: { id: <plan_name> } } } }.
+  // Fall back to a trialing Hobbyist (the entry default) so we never over-grant.
   let tier = 'hobbyist'
+  let status: PlanStatus['status'] = 'trialing'
+  let trialEnd: string | null = null
   try {
     const sub = await ainativeFetch<any>('/api/v1/subscription', accessToken)
-    const planName = sub?.data?.plan_name ?? sub?.plan_name ?? sub?.data?.plan ?? null
-    tier = normalizeTier(planName)
+    const s = sub?.data?.subscription ?? sub?.subscription ?? sub?.data ?? null
+    if (s) {
+      tier = normalizeTier(s?.plan?.id ?? s?.plan?.name ?? s?.plan_name ?? null)
+      const raw = String(s?.status ?? '').toLowerCase()
+      status = raw === 'trialing' || raw === 'trial' ? 'trialing' : raw === 'active' ? 'active' : 'none'
+      trialEnd = s?.trial_end ?? s?.trial_ends_at ?? null
+    } else {
+      status = 'none'
+    }
   } catch {
     tier = 'hobbyist'
+    status = 'trialing'
   }
 
   const limits = TIER_LIMITS[tier] ?? TIER_LIMITS.hobbyist
+  const daysLeft = daysUntil(trialEnd)
 
   // Current usage — count the user's real workspaces + projects.
   const [workspaces, projects] = await Promise.all([
@@ -62,6 +101,13 @@ export async function getPlanStatus(accessToken: string): Promise<PlanStatus> {
 
   return {
     tier,
+    tierLabel: tierLabel(tier),
+    status,
+    trial: {
+      active: status === 'trialing',
+      endsAt: trialEnd,
+      daysLeft: status === 'trialing' ? daysLeft : null,
+    },
     workspaces: slot(workspaces.length, limits.maxWorkspaces),
     projects: slot(projects.length, limits.maxProjects),
   }

--- a/lib/ainative/projects.ts
+++ b/lib/ainative/projects.ts
@@ -8,7 +8,7 @@
  */
 import { ainativeFetch } from './client'
 import {
-  FREE_TIER_MAX_PROJECTS,
+  HOBBYIST_MAX_PROJECTS,
   type Project,
   type ProjectCreateInput,
 } from './types'
@@ -66,10 +66,12 @@ export async function deleteProject(
 }
 
 /**
- * Whether a free-tier user can create another project. Core caps free tier at
- * 3 projects — surfacing this in the UI turns the limit into an upgrade prompt
- * for the paid full-stack tier rather than a silent 4xx on create.
+ * How many more projects a Hobbyist user can create. Core caps the Hobbyist
+ * (entry, $5/7-day-trial) tier at 3 projects — surfacing this in the UI turns
+ * the limit into an upgrade prompt rather than a silent 4xx on create.
  */
-export function freeTierProjectsRemaining(projectCount: number): number {
-  return Math.max(0, FREE_TIER_MAX_PROJECTS - projectCount)
+export function hobbyistProjectsRemaining(projectCount: number): number {
+  return Math.max(0, HOBBYIST_MAX_PROJECTS - projectCount)
 }
+/** @deprecated legacy name — use hobbyistProjectsRemaining. */
+export const freeTierProjectsRemaining = hobbyistProjectsRemaining

--- a/lib/ainative/types.ts
+++ b/lib/ainative/types.ts
@@ -11,9 +11,11 @@
 
 export type WorkspaceRole = 'MEMBER' | 'OWNER' | 'ADMIN'
 export type WorkspaceType = 'personal' | 'client' | 'team'
-export type WorkspaceTier = 'free' | 'pro' | 'team' | 'enterprise'
+// Tiers per core (#128: Hobbyist $5/7-day-trial replaced free). 'free' kept only
+// as a legacy inbound value that normalizes to hobbyist — never customer-facing.
+export type WorkspaceTier = 'hobbyist' | 'pro' | 'team' | 'enterprise' | 'free'
 
-export type ProjectTier = 'free' | 'pro' | 'scale' | 'enterprise'
+export type ProjectTier = 'hobbyist' | 'pro' | 'scale' | 'enterprise' | 'free'
 export type ProjectStatus = 'ACTIVE' | 'SUSPENDED' | 'DELETED'
 
 /** Mirrors WorkspaceItem in app/api/v1/consolidated/workspaces.py */
@@ -78,12 +80,16 @@ export interface ProjectCreateInput {
   organization_id?: string
 }
 
-/** Free-tier caps enforced platform-wide by core get_tier_limits (hobbyist:
- *  max_workspaces=1, max_projects=3). The builder subdomain mirrors these so a
- *  free user gets the SAME limits as on ainative.studio. Core is the hard
- *  gate (403 on create); the builder surfaces them as upgrade prompts. */
-export const FREE_TIER_MAX_PROJECTS = 3
-export const FREE_TIER_MAX_WORKSPACES = 1
+/** Hobbyist (entry tier, $5/7-day trial — replaced "free") caps enforced
+ *  platform-wide by core get_tier_limits: max_workspaces=1, max_projects=3. The
+ *  builder mirrors these so a Hobbyist user gets the SAME limits as on
+ *  ainative.studio. Core is the hard gate (403 on create); the builder surfaces
+ *  them as upgrade prompts. */
+export const HOBBYIST_MAX_PROJECTS = 3
+export const HOBBYIST_MAX_WORKSPACES = 1
+/** @deprecated legacy names — use HOBBYIST_MAX_*. Kept so existing imports don't break. */
+export const FREE_TIER_MAX_PROJECTS = HOBBYIST_MAX_PROJECTS
+export const FREE_TIER_MAX_WORKSPACES = HOBBYIST_MAX_WORKSPACES
 
 export class AINativeApiError extends Error {
   constructor(


### PR DESCRIPTION
Follow-up to #168. **There is no 'free' tier anymore** — core #128 replaced it with **Hobbyist** ($5 entry tier, 7-day trial). #168 propagated stale 'free' terminology (some pre-existing in the builder). The **limits were correct** (1 workspace, 3 projects); the naming + missing trial concept were wrong.

## Corrections (all builder-repo)
- **`plan.ts`**: reads the real `/subscription` shape (`data.subscription.{status, trial_end, plan.id}`); exposes `tier=hobbyist`, `tierLabel`, `status` (`trialing`|`active`|`none`), `trial {active, endsAt, daysLeft}`. `normalizeTier` keeps free/basic/starter/trial as **legacy inbound aliases → hobbyist** (never shown to users).
- **`/api/plan`**: returns tierLabel + trial; safe default is a trialing Hobbyist.
- **`types.ts`**: `HOBBYIST_MAX_{PROJECTS,WORKSPACES}` (old `FREE_TIER_*` kept as deprecated aliases).
- **Workspace switcher**: footer 'Hobbyist · Trial · Nd left · N/1 workspace · N/3 apps'.
- **Projects route/client**: `tierUsage` field (`freeTier` kept for back-compat); 'Hobbyist plan: N of 3 apps'.
- **home-client / upgrade-banner**: 'your plan limit' / 'Plan Limit Reached' / 'your monthly tokens'.
- 403 reasons → `workspace_limit_reached` / `project_limit_reached`.

## Tests
8 plan tests (tierLabel is Hobbyist not free; no `TIER_LIMITS.free`, but 'free' normalizes to hobbyist). Types clean.

Confirms the builder now reflects core's **current** model: Hobbyist + 7-day trial, not 'free'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)