### PR TITLE
fix(plan): remove remaining 'free' tier copy → Hobbyist/trial

### DIFF
--- a/app/compare/[competitor]/page.tsx
+++ b/app/compare/[competitor]/page.tsx
@@ -178,7 +178,7 @@ export default async function CompetitorPage({ params }: PageProps) {
         name: `Is AINative Builder a good ${data.displayName} alternative?`,
         acceptedAnswer: {
           '@type': 'Answer',
-          text: `Yes. AINative Builder is a strong alternative to ${data.displayName} for developers who need multi-model flexibility, agent-optimized output, automatic SEO, and open-source access. It offers a free tier and professional plans starting at $49/mo.`,
+          text: `Yes. AINative Builder is a strong alternative to ${data.displayName} for developers who need multi-model flexibility, agent-optimized output, automatic SEO, and open-source access. It starts with a 7-day trial on the Hobbyist plan, with professional plans from $49/mo.`,
         },
       },
       {
@@ -289,7 +289,7 @@ export default async function CompetitorPage({ params }: PageProps) {
               Switch from {data.displayName} today
             </h2>
             <p className="text-muted-foreground mb-8">
-              Get started for free — no credit card required. Build production-ready React apps
+              Start your 7-day trial on the Hobbyist plan. Build production-ready React apps
               with multi-model AI and AX optimization.
             </p>
             <Button asChild size="lg">

--- a/components/home/home-client.tsx
+++ b/components/home/home-client.tsx
@@ -281,7 +281,7 @@ export function HomeClient() {
           throw new Error('You\'ve reached your generation limit. Upgrade to Pro for 100x more tokens and Claude Sonnet 4.')
         }
         if (response.status === 403 || response.status === 401) {
-          throw new Error('Please create a free account to generate apps. It only takes 10 seconds!')
+          throw new Error('Please sign up to generate apps — it only takes 10 seconds and starts your 7-day trial.')
         }
         let errorMessage = 'Sorry, there was an error processing your message. Please try again.'
         try {

--- a/lib/services/plan.service.ts
+++ b/lib/services/plan.service.ts
@@ -7,7 +7,7 @@
 import { AINATIVE_API_BASE_URL } from '@/lib/constants'
 
 export interface UserPlan {
-  tier: 'free' | 'pro' | 'team' | 'enterprise'
+  tier: 'hobbyist' | 'pro' | 'team' | 'enterprise'
   monthlyTokenLimit: number
   tokensUsed: number
   tokensRemaining: number
@@ -16,10 +16,12 @@ export interface UserPlan {
   defaultModel: string
 }
 
-// Aligned with ainative.studio pricing: Starter, Pro $49, Business $149, Enterprise $699
+// Aligned with ainative.studio pricing. Hobbyist ($5, 7-day trial) is the entry
+// tier that replaced "free"; Pro $49, Business $149, Enterprise $699. Legacy
+// billing values of "free" normalize to hobbyist below.
 const PLAN_CONFIGS: Record<string, Omit<UserPlan, 'tokensUsed' | 'tokensRemaining'>> = {
-  free: {
-    tier: 'free',
+  hobbyist: {
+    tier: 'hobbyist',
     monthlyTokenLimit: 10_000,    // 10K LLM tokens
     maxTokensPerRequest: 4_000,
     models: ['qwen-coder-7b', 'gemma-2b', 'gemma-9b'],
@@ -63,11 +65,13 @@ export async function getUserPlan(accessToken: string): Promise<UserPlan> {
       }),
     ])
 
-    // Determine tier from billing response
-    let tier = 'free'
+    // Determine tier from billing response. Default hobbyist (entry tier that
+    // replaced free); legacy "free"/"starter"/"basic" values normalize to it.
+    let tier = 'hobbyist'
     if (billingRes.status === 'fulfilled' && billingRes.value.ok) {
       const billing = await billingRes.value.json()
-      tier = billing?.data?.plan?.tier || billing?.plan || billing?.tier || 'free'
+      const raw = String(billing?.data?.plan?.tier || billing?.plan || billing?.tier || 'hobbyist').toLowerCase()
+      tier = ['free', 'basic', 'starter', 'trial', 'hobbyist'].includes(raw) ? 'hobbyist' : raw
     }
 
     // Get usage from managed API
@@ -77,7 +81,7 @@ export async function getUserPlan(accessToken: string): Promise<UserPlan> {
       tokensUsed = usage?.total_tokens || usage?.tokens_used || 0
     }
 
-    const planConfig = PLAN_CONFIGS[tier] || PLAN_CONFIGS.free
+    const planConfig = PLAN_CONFIGS[tier] || PLAN_CONFIGS.hobbyist
     return {
       ...planConfig,
       tokensUsed,
@@ -85,11 +89,11 @@ export async function getUserPlan(accessToken: string): Promise<UserPlan> {
     }
   } catch (error) {
     console.error('[Plan Service] Error fetching plan:', error)
-    // Default to free plan on error
+    // Default to the Hobbyist (entry) plan on error — never over-grant.
     return {
-      ...PLAN_CONFIGS.free,
+      ...PLAN_CONFIGS.hobbyist,
       tokensUsed: 0,
-      tokensRemaining: PLAN_CONFIGS.free.monthlyTokenLimit,
+      tokensRemaining: PLAN_CONFIGS.hobbyist.monthlyTokenLimit,
     }
   }
 }
@@ -100,7 +104,7 @@ export async function getUserPlan(accessToken: string): Promise<UserPlan> {
 export function getDefaultPlan(userType: string): UserPlan {
   if (userType === 'guest') {
     return {
-      tier: 'free',
+      tier: 'hobbyist',
       monthlyTokenLimit: 10_000,
       tokensUsed: 0,
       tokensRemaining: 10_000,


### PR DESCRIPTION
Follow-up sweep after #169 — found stale 'free' in 3 more places:

- **`lib/services/plan.service.ts`**: a **separate** token-limit plan service still had a `free` tier config + defaulted to it. Renamed entry tier free→hobbyist (type, PLAN_CONFIGS, both fallbacks, guest default); normalizes legacy inbound free/basic/starter → hobbyist. Its only consumer (`/api/credits`) passes the plan through — no broken comparisons.
- **`app/compare/[competitor]/page.tsx`** (public SEO): 'It offers a free tier' + 'Get started for free — no credit card required' were false → '7-day trial on the Hobbyist plan, professional plans from $49/mo'.
- **home-client**: 'create a free account' → 'sign up … starts your 7-day trial'.

Full-repo sweep now shows **no user-facing 'free' tier/plan copy remaining** (intentional exceptions: deprecated aliases, inbound normalize lists, internal model-routing comment, ZeroDB-included-free, and template content generated for *users' own apps*). Types clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)