### PR TITLE
fix(seo): make /compare competitor pages public + indexed

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -13,6 +13,15 @@ export default function sitemap(): MetadataRoute.Sitemap {
     priority: entry.featured ? 0.9 : 0.8,
   }))
 
+  // Competitor-comparison SEO pages ("<X> alternative") — high-intent search.
+  // Keep in sync with COMPETITORS in app/compare/[competitor]/page.tsx.
+  const compareEntries: MetadataRoute.Sitemap = ['v0', 'lovable', 'bolt', 'base44'].map(slug => ({
+    url: `${baseUrl}/compare/${slug}`,
+    lastModified: now,
+    changeFrequency: 'weekly' as const,
+    priority: 0.85,
+  }))
+
   return [
     {
       url: baseUrl,
@@ -27,6 +36,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.95,
     },
     ...showcaseEntries,
+    ...compareEntries,
     {
       url: `${baseUrl}/templates`,
       lastModified: now,

--- a/middleware.ts
+++ b/middleware.ts
@@ -88,6 +88,14 @@ export async function middleware(request: NextRequest) {
       return NextResponse.next()
     }
 
+    // Allow the competitor-comparison SEO pages for anonymous users — these are
+    // public marketing/landing pages ("<X> alternative") that MUST be crawlable
+    // by search engines and viewable without an account. They were 307→/login,
+    // which blocked indexing entirely.
+    if (pathname.startsWith('/compare')) {
+      return NextResponse.next()
+    }
+
     // Allow preview routes for anonymous users
     if (pathname.startsWith('/preview/')) {
       return NextResponse.next()


### PR DESCRIPTION
The `/compare/[competitor]` SEO pages (v0/lovable/bolt/base44 'alternative') were **307-redirecting to /login** and were **absent from the sitemap** — so search engines couldn't crawl them and anonymous visitors couldn't view them at all. They ship full SEO metadata (title, description, JSON-LD FAQ) but were completely hidden.

- **middleware**: allow `/compare` for anonymous users (same treatment as `/showcase`, `/preview`).
- **sitemap**: add the four `/compare/*` URLs (kept in sync with COMPETITORS).

Found while verifying the Hobbyist copy correction on these pages — a copy fix is moot if the page redirects to login. Now the corrected '7-day trial on the Hobbyist plan' comparison pages are publicly crawlable. (Relates to SEO #32.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)