### PR TITLE
feat(seo): add /guides blog section with indexable long-tail articles (#35)

### DIFF
--- a/__tests__/lib/seo-guides.test.ts
+++ b/__tests__/lib/seo-guides.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Unit tests for the SEO guides catalog (Issue #35).
+ *
+ * These guides power the /guides blog/tutorials hub and the individually
+ * indexable /guides/[slug] long-form articles. The tests guard the contract
+ * those pages + the sitemap rely on:
+ *   - at least the four required long-tail articles
+ *   - unique, URL-safe slugs
+ *   - required rich-content fields present (intro, sections, faqs, keywords…)
+ *   - the specific issue-mandated topics exist and target their keywords
+ *   - lookup + generateStaticParams inputs stay in sync
+ */
+
+import { describe, it, expect } from 'vitest'
+import { GUIDES, GUIDE_SLUGS, getGuideBySlug } from '@/lib/data/seo-guides'
+
+describe('SEO guides catalog', () => {
+  it('exposes at least 4 guides', () => {
+    expect(GUIDES.length).toBeGreaterThanOrEqual(4)
+  })
+
+  it('has unique slugs', () => {
+    const slugs = GUIDES.map((g) => g.slug)
+    expect(new Set(slugs).size).toBe(slugs.length)
+  })
+
+  it('has URL-safe slugs (lowercase, hyphenated)', () => {
+    for (const g of GUIDES) {
+      expect(g.slug).toMatch(/^[a-z0-9]+(?:-[a-z0-9]+)*$/)
+    }
+  })
+
+  it('exposes a unique title per guide', () => {
+    const titles = GUIDES.map((g) => g.title)
+    expect(new Set(titles).size).toBe(titles.length)
+  })
+
+  it('keeps GUIDE_SLUGS in sync with the catalog', () => {
+    expect(GUIDE_SLUGS).toHaveLength(GUIDES.length)
+    expect(GUIDE_SLUGS).toEqual(GUIDES.map((g) => g.slug))
+  })
+
+  it('provides rich, indexable content for every guide', () => {
+    for (const g of GUIDES) {
+      // Excerpt/intro must be substantial for SEO (not stubs).
+      expect(g.excerpt.length).toBeGreaterThanOrEqual(60)
+      expect(g.intro.length).toBeGreaterThanOrEqual(40)
+      expect(g.title.length).toBeGreaterThan(10)
+      expect(['Tutorial', 'Comparison', 'Concept', 'Best Practices']).toContain(
+        g.category
+      )
+      expect(g.readTimeMinutes).toBeGreaterThan(0)
+
+      // Keywords / tags for meta + JSON-LD.
+      expect(g.keywords.length).toBeGreaterThanOrEqual(3)
+      expect(g.tags.length).toBeGreaterThanOrEqual(1)
+
+      // Body sections with real prose.
+      expect(g.sections.length).toBeGreaterThanOrEqual(3)
+      for (const s of g.sections) {
+        expect(s.heading).toBeTruthy()
+        expect(s.paragraphs.length).toBeGreaterThanOrEqual(1)
+        for (const p of s.paragraphs) {
+          expect(p.length).toBeGreaterThanOrEqual(80)
+        }
+      }
+
+      // FAQ entries for FAQPage JSON-LD.
+      expect(g.faqs.length).toBeGreaterThanOrEqual(2)
+      for (const f of g.faqs) {
+        expect(f.question).toBeTruthy()
+        expect(f.answer.length).toBeGreaterThanOrEqual(40)
+      }
+    }
+  })
+
+  it('uses valid, non-future publish/modified dates', () => {
+    for (const g of GUIDES) {
+      expect(g.datePublished).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+      expect(g.dateModified).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+      expect(Number.isNaN(Date.parse(g.datePublished))).toBe(false)
+      expect(Number.isNaN(Date.parse(g.dateModified))).toBe(false)
+      // Modified should not predate published.
+      expect(Date.parse(g.dateModified)).toBeGreaterThanOrEqual(
+        Date.parse(g.datePublished)
+      )
+    }
+  })
+
+  it('includes the issue-mandated long-tail articles', () => {
+    const slugs = new Set(GUIDE_SLUGS)
+    expect(slugs.has('how-to-build-a-saas-with-ai')).toBe(true)
+    expect(slugs.has('v0-vs-lovable-vs-ainative')).toBe(true)
+    expect(slugs.has('what-is-ax-optimization')).toBe(true)
+  })
+
+  it('targets the intended long-tail keyword in each mandated article', () => {
+    const cases: Array<[string, string]> = [
+      ['how-to-build-a-saas-with-ai', 'how to build a saas with ai'],
+      ['v0-vs-lovable-vs-ainative', 'v0 vs lovable vs ainative'],
+      ['what-is-ax-optimization', 'what is ax optimization'],
+    ]
+    for (const [slug, keyword] of cases) {
+      const guide = getGuideBySlug(slug)
+      expect(guide).toBeDefined()
+      const hasKeyword = guide!.keywords.some(
+        (k) => k.toLowerCase() === keyword
+      )
+      expect(hasKeyword).toBe(true)
+    }
+  })
+})
+
+describe('getGuideBySlug', () => {
+  it('returns the matching guide for a known slug', () => {
+    const g = getGuideBySlug('what-is-ax-optimization')
+    expect(g).toBeDefined()
+    expect(g?.category).toBe('Concept')
+  })
+
+  it('returns undefined for an unknown slug', () => {
+    expect(getGuideBySlug('does-not-exist')).toBeUndefined()
+  })
+
+  it('resolves every slug in the catalog', () => {
+    for (const slug of GUIDE_SLUGS) {
+      expect(getGuideBySlug(slug)).toBeDefined()
+    }
+  })
+})

--- a/__tests__/lib/sitemap-guides.test.ts
+++ b/__tests__/lib/sitemap-guides.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Ensures every blog/guides article (Issue #35) is present in the sitemap so
+ * search engines discover them, and that the /guides index is listed too.
+ */
+
+import { describe, it, expect } from 'vitest'
+import sitemap from '@/app/sitemap'
+import { GUIDE_SLUGS } from '@/lib/data/seo-guides'
+
+describe('sitemap — guides articles', () => {
+  const entries = sitemap()
+  const urls = entries.map((e) => e.url)
+
+  it('includes a URL for every guide slug', () => {
+    for (const slug of GUIDE_SLUGS) {
+      expect(urls).toContain(`https://builder.ainative.studio/guides/${slug}`)
+    }
+  })
+
+  it('includes the guides index page', () => {
+    expect(urls).toContain('https://builder.ainative.studio/guides')
+  })
+
+  it('emits no duplicate URLs', () => {
+    expect(new Set(urls).size).toBe(urls.length)
+  })
+})

--- a/app/guides/[slug]/page.tsx
+++ b/app/guides/[slug]/page.tsx
@@ -1,0 +1,262 @@
+import { notFound } from 'next/navigation'
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { AppHeader } from '@/components/shared/app-header'
+import { GUIDES, GUIDE_SLUGS, getGuideBySlug } from '@/lib/data/seo-guides'
+
+interface PageProps {
+  params: Promise<{ slug: string }>
+}
+
+const BASE_URL = 'https://builder.ainative.studio'
+
+// Statically pre-render one page per guide so every article is crawlable and
+// indexable without hitting the database at request time.
+export function generateStaticParams() {
+  return GUIDE_SLUGS.map((slug) => ({ slug }))
+}
+
+export const dynamicParams = false
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { slug } = await params
+  const guide = getGuideBySlug(slug)
+
+  if (!guide) {
+    return { title: 'Guide Not Found | AINative Builder' }
+  }
+
+  const title = `${guide.title} | AINative Builder`
+
+  return {
+    title,
+    description: guide.excerpt,
+    keywords: [...guide.keywords, ...guide.tags, 'AINative Builder'],
+    authors: [{ name: 'AINative' }],
+    openGraph: {
+      title,
+      description: guide.excerpt,
+      type: 'article',
+      url: `${BASE_URL}/guides/${slug}`,
+      publishedTime: guide.datePublished,
+      modifiedTime: guide.dateModified,
+      tags: guide.tags,
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description: guide.excerpt,
+    },
+    alternates: {
+      canonical: `${BASE_URL}/guides/${slug}`,
+    },
+  }
+}
+
+export default async function GuidePage({ params }: PageProps) {
+  const { slug } = await params
+  const guide = getGuideBySlug(slug)
+
+  if (!guide) {
+    notFound()
+  }
+
+  // Related guides: same tags first, then any others.
+  const related = GUIDES.filter(
+    (g) => g.slug !== guide.slug && g.tags.some((t) => guide.tags.includes(t))
+  )
+  const relatedGuides = (
+    related.length > 0 ? related : GUIDES.filter((g) => g.slug !== guide.slug)
+  ).slice(0, 3)
+
+  const articleJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: guide.title,
+    description: guide.excerpt,
+    articleSection: guide.category,
+    keywords: guide.keywords.join(', '),
+    datePublished: guide.datePublished,
+    dateModified: guide.dateModified,
+    author: { '@type': 'Organization', name: 'AINative' },
+    publisher: {
+      '@type': 'Organization',
+      name: 'AINative Builder',
+      url: BASE_URL,
+    },
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': `${BASE_URL}/guides/${slug}`,
+    },
+  }
+
+  const faqJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: guide.faqs.map((faq) => ({
+      '@type': 'Question',
+      name: faq.question,
+      acceptedAnswer: { '@type': 'Answer', text: faq.answer },
+    })),
+  }
+
+  const breadcrumbJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'Guides', item: `${BASE_URL}/guides` },
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name: guide.title,
+        item: `${BASE_URL}/guides/${slug}`,
+      },
+    ],
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleJsonLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
+      />
+      <AppHeader />
+
+      <main className="container mx-auto px-4 py-12 max-w-3xl">
+        {/* Breadcrumb */}
+        <nav className="text-sm text-muted-foreground mb-8" aria-label="Breadcrumb">
+          <Link href="/guides" className="hover:text-foreground transition-colors">
+            Guides
+          </Link>
+          <span className="mx-2">/</span>
+          <span className="text-foreground">{guide.title}</span>
+        </nav>
+
+        {/* Header */}
+        <article>
+          <header className="mb-8">
+            <div className="flex flex-wrap items-center gap-3 mb-4">
+              <Badge variant="secondary">{guide.category}</Badge>
+              <span className="text-sm text-muted-foreground">
+                {guide.readTimeMinutes} min read
+              </span>
+              <span className="text-sm text-muted-foreground">·</span>
+              <time
+                className="text-sm text-muted-foreground"
+                dateTime={guide.dateModified}
+              >
+                Updated{' '}
+                {new Date(guide.dateModified).toLocaleDateString('en-US', {
+                  year: 'numeric',
+                  month: 'long',
+                  day: 'numeric',
+                })}
+              </time>
+            </div>
+            <h1 className="text-4xl font-bold mb-4 leading-tight">{guide.title}</h1>
+            <p className="text-lg text-muted-foreground leading-relaxed">
+              {guide.intro}
+            </p>
+          </header>
+
+          {/* Body sections */}
+          <div className="space-y-10">
+            {guide.sections.map((section) => (
+              <section key={section.heading}>
+                <h2 className="text-2xl font-bold mb-4">{section.heading}</h2>
+                <div className="space-y-4">
+                  {section.paragraphs.map((para, i) => (
+                    <p
+                      key={i}
+                      className="text-muted-foreground leading-relaxed"
+                    >
+                      {para}
+                    </p>
+                  ))}
+                </div>
+                {section.bullets && section.bullets.length > 0 && (
+                  <ul className="mt-4 space-y-2">
+                    {section.bullets.map((bullet) => (
+                      <li key={bullet} className="flex gap-3">
+                        <span
+                          aria-hidden
+                          className="mt-1 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary text-xs"
+                        >
+                          ✓
+                        </span>
+                        <span className="text-muted-foreground">{bullet}</span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </section>
+            ))}
+          </div>
+
+          {/* CTA */}
+          <div className="border-t mt-12 pt-10 text-center">
+            <h2 className="text-2xl font-bold mb-3">Start building with AI</h2>
+            <p className="text-muted-foreground mb-6">
+              Turn a prompt into a production-ready app in seconds with AINative
+              Builder.
+            </p>
+            <Button asChild size="lg">
+              <Link href="/">Try AINative Builder Free</Link>
+            </Button>
+          </div>
+
+          {/* FAQ */}
+          {guide.faqs.length > 0 && (
+            <section className="border-t mt-12 pt-10">
+              <h2 className="text-2xl font-bold mb-6">Frequently asked questions</h2>
+              <div className="space-y-6">
+                {guide.faqs.map((faq) => (
+                  <div key={faq.question} className="border rounded-lg p-6">
+                    <h3 className="font-semibold text-lg mb-3">{faq.question}</h3>
+                    <p className="text-muted-foreground leading-relaxed">
+                      {faq.answer}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </section>
+          )}
+        </article>
+
+        {/* Related guides — internal linking for SEO */}
+        {relatedGuides.length > 0 && (
+          <section className="border-t mt-12 pt-10">
+            <h2 className="text-xl font-bold mb-6">Related guides</h2>
+            <div className="grid gap-4 sm:grid-cols-3">
+              {relatedGuides.map((rel) => (
+                <Link
+                  key={rel.slug}
+                  href={`/guides/${rel.slug}`}
+                  className="rounded-lg border p-4 hover:border-primary hover:shadow-sm transition-all"
+                >
+                  <Badge variant="secondary" className="mb-2 text-xs">
+                    {rel.category}
+                  </Badge>
+                  <h3 className="font-semibold mb-1">{rel.title}</h3>
+                  <p className="text-sm text-muted-foreground line-clamp-2">
+                    {rel.excerpt}
+                  </p>
+                </Link>
+              ))}
+            </div>
+          </section>
+        )}
+      </main>
+    </div>
+  )
+}

--- a/app/guides/page.tsx
+++ b/app/guides/page.tsx
@@ -1,0 +1,123 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { Badge } from '@/components/ui/badge'
+import { AppHeader } from '@/components/shared/app-header'
+import { GUIDES } from '@/lib/data/seo-guides'
+
+const BASE_URL = 'https://builder.ainative.studio'
+
+export const metadata: Metadata = {
+  title: 'Guides & Tutorials — Build Apps with AI | AINative Builder',
+  description:
+    'Long-form guides on building SaaS with AI, AI app builder comparisons (v0 vs Lovable vs AINative), AX optimization, and SEO best practices for AI-generated apps.',
+  keywords: [
+    'AI app builder guides',
+    'how to build a SaaS with AI',
+    'v0 vs Lovable vs AINative',
+    'what is AX optimization',
+    'SEO for AI-generated apps',
+    'AINative Builder tutorials',
+  ],
+  openGraph: {
+    title: 'Guides & Tutorials — Build Apps with AI | AINative Builder',
+    description:
+      'Long-form guides on building SaaS with AI, builder comparisons, AX optimization, and SEO best practices.',
+    type: 'website',
+    url: `${BASE_URL}/guides`,
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Guides & Tutorials — Build Apps with AI | AINative Builder',
+    description:
+      'Long-form guides on building SaaS with AI, builder comparisons, AX optimization, and SEO best practices.',
+  },
+  alternates: {
+    canonical: `${BASE_URL}/guides`,
+  },
+}
+
+const categoryColor: Record<string, string> = {
+  Tutorial: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
+  Comparison: 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200',
+  Concept: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
+  'Best Practices': 'bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200',
+}
+
+export default function GuidesIndexPage() {
+  // ItemList structured data helps search engines understand the article hub.
+  const itemListJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    name: 'AINative Builder Guides',
+    itemListElement: GUIDES.map((guide, i) => ({
+      '@type': 'ListItem',
+      position: i + 1,
+      url: `${BASE_URL}/guides/${guide.slug}`,
+      name: guide.title,
+    })),
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(itemListJsonLd) }}
+      />
+      <AppHeader />
+
+      <main className="container mx-auto px-4 py-12 max-w-4xl">
+        {/* Header */}
+        <div className="mb-10 text-center">
+          <Badge variant="secondary" className="mb-4">
+            Guides &amp; Tutorials
+          </Badge>
+          <h1 className="text-4xl md:text-5xl font-bold mb-4">
+            Learn to build apps with AI
+          </h1>
+          <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
+            In-depth guides on building SaaS with AI, comparing AI app builders,
+            optimizing for AI agents (AX), and making AI-generated apps rank in
+            search.
+          </p>
+        </div>
+
+        {/* Article grid */}
+        <div className="grid gap-6 sm:grid-cols-2">
+          {GUIDES.map((guide) => (
+            <Link
+              key={guide.slug}
+              href={`/guides/${guide.slug}`}
+              className="group flex flex-col rounded-lg border p-6 hover:border-primary hover:shadow-sm transition-all"
+            >
+              <div className="mb-3 flex items-center gap-3">
+                <span
+                  className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                    categoryColor[guide.category] ?? ''
+                  }`}
+                >
+                  {guide.category}
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  {guide.readTimeMinutes} min read
+                </span>
+              </div>
+              <h2 className="text-xl font-semibold mb-2 group-hover:text-primary transition-colors">
+                {guide.title}
+              </h2>
+              <p className="text-sm text-muted-foreground leading-relaxed flex-1">
+                {guide.excerpt}
+              </p>
+              <div className="mt-4 flex flex-wrap gap-2">
+                {guide.tags.slice(0, 3).map((tag) => (
+                  <Badge key={tag} variant="outline" className="text-xs">
+                    {tag}
+                  </Badge>
+                ))}
+              </div>
+            </Link>
+          ))}
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,6 +1,7 @@
 import { MetadataRoute } from 'next'
 import { SEED_SHOWCASE } from '@/lib/showcase-data'
 import { TEMPLATE_SLUGS } from '@/lib/data/seo-templates'
+import { GUIDE_SLUGS } from '@/lib/data/seo-guides'
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const baseUrl = 'https://builder.ainative.studio'
@@ -32,6 +33,16 @@ export default function sitemap(): MetadataRoute.Sitemap {
     priority: 0.8,
   }))
 
+  // Blog/guides articles targeting long-tail keywords ("how to build a SaaS with
+  // AI", "v0 vs Lovable vs AINative", "what is AX optimization"). One URL per
+  // article; keep in sync with lib/data/seo-guides.ts.
+  const guideEntries: MetadataRoute.Sitemap = GUIDE_SLUGS.map(slug => ({
+    url: `${baseUrl}/guides/${slug}`,
+    lastModified: now,
+    changeFrequency: 'monthly' as const,
+    priority: 0.8,
+  }))
+
   return [
     {
       url: baseUrl,
@@ -54,6 +65,13 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.9,
     },
     ...templateEntries,
+    {
+      url: `${baseUrl}/guides`,
+      lastModified: now,
+      changeFrequency: 'weekly',
+      priority: 0.85,
+    },
+    ...guideEntries,
     {
       url: `${baseUrl}/login`,
       lastModified: now,

--- a/components/shared/app-header.tsx
+++ b/components/shared/app-header.tsx
@@ -10,7 +10,7 @@ import { UserNavClient } from '@/components/user-nav-client'
 import { WorkspaceSwitcher } from '@/components/workspace-switcher'
 import { Button } from '@/components/ui/button'
 import { DEPLOY_URL, APP_NAME } from '@/lib/constants'
-import { LayoutTemplate, Rocket, Settings } from 'lucide-react'
+import { BookOpen, LayoutTemplate, Rocket, Settings } from 'lucide-react'
 import {
   Dialog,
   DialogContent,
@@ -100,6 +100,13 @@ export function AppHeader({ className = '' }: AppHeaderProps) {
 
           {/* Desktop right side - Navigation + User */}
           <div className="hidden lg:flex items-center gap-4">
+            {/* Public SEO link — visible to everyone, including crawlers */}
+            <Button variant="ghost" size="sm" asChild>
+              <Link href="/guides">
+                <BookOpen className="w-4 h-4 mr-1" />
+                Guides
+              </Link>
+            </Button>
             {session && (
               <>
                 <Button variant="ghost" size="sm" asChild>

--- a/lib/data/seo-guides.ts
+++ b/lib/data/seo-guides.ts
@@ -1,0 +1,363 @@
+/**
+ * SEO Guides Catalog — single source of truth for the blog/guides section that
+ * powers the individually indexable long-form articles at /guides/[slug] and the
+ * /guides index (Issue #35).
+ *
+ * These are static, build-time data (NOT fetched from the DB at request time) so
+ * that each article can be statically generated, crawled, and indexed by search
+ * engines. Each entry targets a specific long-tail keyword search intent
+ * (e.g. "how to build a SaaS with AI", "v0 vs Lovable vs AINative",
+ * "what is AX optimization").
+ *
+ * Keep this list in sync with:
+ *   - app/guides/[slug]/page.tsx (generateStaticParams reads GUIDE_SLUGS)
+ *   - app/guides/page.tsx (renders the index of GUIDES)
+ *   - app/sitemap.ts (emits one URL per slug)
+ */
+
+/** A single content section rendered as an <h2> + paragraphs on the article. */
+export interface GuideSection {
+  /** Section heading (rendered as <h2>). */
+  heading: string
+  /** One or more paragraphs of body copy. */
+  paragraphs: string[]
+  /** Optional bullet list rendered under the paragraphs. */
+  bullets?: string[]
+}
+
+/** A frequently-asked question rendered on the page + emitted as FAQ JSON-LD. */
+export interface GuideFaq {
+  question: string
+  answer: string
+}
+
+export interface SeoGuide {
+  /** URL slug — must be unique and URL-safe. */
+  slug: string
+  /** Article title (used as <h1> + <title>). */
+  title: string
+  /** Short one-line summary (used in cards + meta description). */
+  excerpt: string
+  /** Top-level content category, shown as a badge and used for grouping. */
+  category: 'Tutorial' | 'Comparison' | 'Concept' | 'Best Practices'
+  /** SEO keywords for <meta keywords> + JSON-LD. */
+  keywords: string[]
+  /** Short tags shown as pills + used for "related" grouping. */
+  tags: string[]
+  /** Estimated read time in minutes (shown in the byline). */
+  readTimeMinutes: number
+  /** ISO date the article was published (used in metadata + JSON-LD). */
+  datePublished: string
+  /** ISO date the article was last updated. */
+  dateModified: string
+  /** A single-sentence lede shown under the title. */
+  intro: string
+  /** The ordered body sections of the article. */
+  sections: GuideSection[]
+  /** FAQ entries — rendered on the page and emitted as FAQPage JSON-LD. */
+  faqs: GuideFaq[]
+}
+
+export const GUIDES: SeoGuide[] = [
+  {
+    slug: 'how-to-build-a-saas-with-ai',
+    title: 'How to Build a SaaS with AI (2026 Step-by-Step Guide)',
+    excerpt:
+      'A practical, end-to-end walkthrough for shipping a production SaaS using AI app builders — from idea to auth, database, payments, and deploy.',
+    category: 'Tutorial',
+    keywords: [
+      'how to build a SaaS with AI',
+      'build a SaaS with AI',
+      'AI SaaS builder',
+      'build a SaaS app fast',
+      'no-code SaaS with AI',
+      'AI app builder tutorial',
+    ],
+    tags: ['SaaS', 'Tutorial', 'AI', 'Full-stack', 'Deployment'],
+    readTimeMinutes: 9,
+    datePublished: '2026-01-15',
+    dateModified: '2026-08-01',
+    intro:
+      'You no longer need a full engineering team to launch a SaaS. With an AI app builder you can go from a one-line prompt to a deployed, multi-page product in an afternoon. This guide shows you exactly how.',
+    sections: [
+      {
+        heading: 'Start with a sharp problem, not a feature list',
+        paragraphs: [
+          'The single biggest predictor of a successful SaaS is a clearly-defined problem for a specific audience. Before you write a single prompt, describe your product in one sentence: who it is for, the painful job they are hiring it to do, and the outcome they get. AI builders are exceptionally good at turning a crisp description into working UI, but they cannot invent product-market fit for you.',
+          'Write the sentence down, then expand it into a short spec: the three core screens, the key data objects, and the one action that delivers value. That spec becomes the prompt you feed the builder.',
+        ],
+      },
+      {
+        heading: 'Generate the UI from a prompt',
+        paragraphs: [
+          'Open AINative Builder and describe your app in plain English — for example, "a project management app with a dashboard, a kanban board, and a settings page." The builder streams back real, editable React code using production components (shadcn/ui), not throwaway mockups. Because the output is real code, you can iterate: ask for a dark mode, add a filter, or change the layout, and the diff is applied live.',
+          'Work screen by screen. Generate the dashboard, review it in the live preview, then move to the next screen. Small, focused prompts produce cleaner code than one giant prompt trying to build everything at once.',
+        ],
+        bullets: [
+          'Describe one screen per prompt for the cleanest output',
+          'Use the live preview to verify each iteration before moving on',
+          'Ask for accessibility and responsive behavior explicitly',
+        ],
+      },
+      {
+        heading: 'Add a database and real data',
+        paragraphs: [
+          'A SaaS needs to persist data. AINative Builder wires generated apps to a hosted data layer (ZeroDB) so your CRUD screens actually read and write live records instead of using hardcoded arrays. Describe your entities — "users have projects, projects have tasks" — and let the builder scaffold the schema and the queries.',
+          'Keep your data model small at first. Ship with the two or three objects that deliver the core value, and add more once real users tell you what is missing.',
+        ],
+      },
+      {
+        heading: 'Layer in auth, payments, and deploy',
+        paragraphs: [
+          'Authentication and billing are the two pieces every SaaS shares. Add sign-in, gate the app behind a login, and connect a payments provider for subscriptions. Then deploy — a single click ships your app to a public URL with automatic HTTPS, so you can share it with your first users the same day.',
+          'Because the builder emits standard React and exports open-source code, you are never locked in: you can keep iterating inside the builder or take the codebase and run it anywhere.',
+        ],
+        bullets: [
+          'Gate the app behind authentication before launch',
+          'Start with a single paid plan; add tiers later',
+          'Deploy early and iterate against real usage',
+        ],
+      },
+    ],
+    faqs: [
+      {
+        question: 'Can I really build a SaaS with AI without coding?',
+        answer:
+          'Yes. AI app builders like AINative Builder generate real, production-ready React code from plain-English prompts, so you can build and ship a functional SaaS without writing code yourself. Because the output is standard code, developers can also jump in and customize it at any point.',
+      },
+      {
+        question: 'How long does it take to build a SaaS with an AI builder?',
+        answer:
+          'A focused MVP with a few screens, a database, auth, and deploy can be built in an afternoon. The timeline depends mostly on how clearly you have defined the problem and the core screens before you start prompting.',
+      },
+      {
+        question: 'Will I be locked into the AI builder?',
+        answer:
+          'Not with AINative Builder. It emits open-source React code that you own and can export, so you can continue in the builder or take the codebase and host it independently.',
+      },
+    ],
+  },
+  {
+    slug: 'v0-vs-lovable-vs-ainative',
+    title: 'v0 vs Lovable vs AINative: The 2026 AI App Builder Comparison',
+    excerpt:
+      'An honest, feature-by-feature comparison of v0, Lovable, and AINative Builder across models, SEO, agent optimization, pricing, and code ownership.',
+    category: 'Comparison',
+    keywords: [
+      'v0 vs Lovable vs AINative',
+      'v0 vs Lovable',
+      'Lovable alternative',
+      'v0 alternative',
+      'best AI app builder 2026',
+      'AI UI generator comparison',
+    ],
+    tags: ['Comparison', 'v0', 'Lovable', 'AINative', 'AI builders'],
+    readTimeMinutes: 8,
+    datePublished: '2026-02-10',
+    dateModified: '2026-08-01',
+    intro:
+      'v0, Lovable, and AINative Builder all turn prompts into apps — but they make very different trade-offs. Here is how they compare on the things that actually matter when you ship real products.',
+    sections: [
+      {
+        heading: 'Model choice: one model vs many',
+        paragraphs: [
+          'v0 and Lovable are effectively single-model tools — you get whatever frontier model they have wired up, with little say in the matter. AINative Builder is multi-model: you can generate with Claude, Qwen, Gemma, or DeepSeek and pick the model that best fits the task and your budget. That flexibility matters because different models excel at different kinds of generation, and pricing varies widely.',
+        ],
+        bullets: [
+          'v0: single hosted model',
+          'Lovable: single hosted model',
+          'AINative: multi-model (Claude, Qwen, Gemma, DeepSeek)',
+        ],
+      },
+      {
+        heading: 'SEO and structured data',
+        paragraphs: [
+          'Most AI builders produce client-rendered apps with no consideration for search engines. AINative Builder is different: it generates SEO-friendly output with automatic JSON-LD structured data and a sitemap, so the apps and landing pages you ship can actually be found. If organic discovery matters to your product, this is a decisive difference.',
+        ],
+      },
+      {
+        heading: 'Agent optimization (AX)',
+        paragraphs: [
+          'AINative Builder includes built-in AX (Agent Experience) scoring — it evaluates how well your generated app can be operated by AI agents, not just humans. As more traffic becomes agent-driven, shipping agent-accessible interfaces becomes a real advantage. Neither v0 nor Lovable offers this today.',
+        ],
+      },
+      {
+        heading: 'Code ownership and pricing',
+        paragraphs: [
+          'AINative Builder emits open-source React code you fully own and can export, whereas v0 and Lovable keep you closer to their platforms. On price, all three offer an entry point and paid tiers; AINative starts with a 7-day trial on the Hobbyist plan with professional plans from $49/mo. The right choice depends on whether you value multi-model flexibility, SEO, and agent optimization — the areas where AINative pulls ahead.',
+        ],
+      },
+    ],
+    faqs: [
+      {
+        question: 'What is the main difference between v0, Lovable, and AINative?',
+        answer:
+          'v0 and Lovable are single-model builders focused on fast UI generation. AINative Builder adds multi-model AI (Claude, Qwen, Gemma, DeepSeek), automatic SEO with structured data, built-in AX (agent) optimization, and open-source code ownership.',
+      },
+      {
+        question: 'Which AI app builder is best for SEO?',
+        answer:
+          'AINative Builder is built for SEO — it generates automatic JSON-LD structured data and sitemaps so your apps and landing pages are crawlable and indexable. v0 and Lovable do not provide built-in SEO tooling.',
+      },
+      {
+        question: 'Is AINative a good v0 or Lovable alternative?',
+        answer:
+          'Yes. AINative is a strong alternative for teams that want multi-model flexibility, agent-optimized output, automatic SEO, and full ownership of open-source code — capabilities that v0 and Lovable do not offer.',
+      },
+    ],
+  },
+  {
+    slug: 'what-is-ax-optimization',
+    title: 'What Is AX Optimization? A Guide to Agent Experience',
+    excerpt:
+      'AX (Agent Experience) optimization makes your app usable by AI agents, not just people. Learn what it is, why it matters, and how to score well.',
+    category: 'Concept',
+    keywords: [
+      'what is AX optimization',
+      'AX optimization',
+      'agent experience',
+      'agent accessibility',
+      'AI agent optimization',
+      'agentic web',
+    ],
+    tags: ['AX', 'Concept', 'Agents', 'Accessibility', 'SEO'],
+    readTimeMinutes: 6,
+    datePublished: '2026-03-05',
+    dateModified: '2026-08-01',
+    intro:
+      'AX — Agent Experience — is the discipline of designing software so that AI agents can perceive, understand, and operate it reliably. It is fast becoming as important as UX and SEO.',
+    sections: [
+      {
+        heading: 'From UX and SEO to AX',
+        paragraphs: [
+          'For two decades we optimized for two audiences: humans (UX) and search-engine crawlers (SEO). A third audience is now arriving at scale — autonomous AI agents that browse, click, fill forms, and complete tasks on a user\'s behalf. AX optimization is the practice of making sure those agents can succeed. A site that is beautiful to a human but opaque to an agent will lose traffic and transactions as agent-driven usage grows.',
+        ],
+      },
+      {
+        heading: 'What makes an app agent-accessible',
+        paragraphs: [
+          'Agent accessibility overlaps heavily with good accessibility and good SEO, but adds its own requirements. Agents rely on semantic structure, predictable interactions, machine-readable metadata, and stable, well-labeled actions to navigate an interface without a human in the loop.',
+        ],
+        bullets: [
+          'Semantic HTML with clear landmarks and headings',
+          'Descriptive, stable labels on every actionable element',
+          'Machine-readable structured data (JSON-LD) describing the page',
+          'Predictable, non-flaky interactions and states',
+          'Documented APIs or endpoints agents can call directly',
+        ],
+      },
+      {
+        heading: 'How AX scoring works',
+        paragraphs: [
+          'An AX score evaluates a page against these criteria and returns a rating that tells you how well an agent could operate it. AINative Builder includes built-in AX scoring so that every app you generate is measured for agent-accessibility as you build — surfacing gaps like missing labels or absent structured data before you ship, rather than after an agent fails to complete a task.',
+          'Treat the AX score the way you treat a Lighthouse score: a fast, actionable signal you improve iteratively.',
+        ],
+      },
+      {
+        heading: 'Why it matters now',
+        paragraphs: [
+          'Agent traffic is compounding. Assistants and autonomous agents increasingly complete purchases, bookings, and workflows directly. Products that are agent-ready capture that demand; products that are not become invisible to it. Optimizing for AX today is the same strategic bet that optimizing for mobile or for search was in earlier eras.',
+        ],
+      },
+    ],
+    faqs: [
+      {
+        question: 'What does AX optimization mean?',
+        answer:
+          'AX (Agent Experience) optimization is the practice of designing an app so AI agents can perceive, understand, and operate it reliably — using semantic structure, stable labels, machine-readable metadata, and predictable interactions.',
+      },
+      {
+        question: 'How is AX different from SEO and accessibility?',
+        answer:
+          'SEO optimizes for search crawlers and accessibility optimizes for humans with assistive technology. AX builds on both but targets autonomous AI agents that navigate and complete tasks without a human, adding requirements like machine-readable actions and structured data.',
+      },
+      {
+        question: 'How do I measure my AX score?',
+        answer:
+          'AINative Builder includes built-in AX scoring that evaluates generated apps against agent-accessibility criteria and surfaces gaps like missing labels or structured data as you build, so you can fix them before shipping.',
+      },
+    ],
+  },
+  {
+    slug: 'ai-app-builder-seo-best-practices',
+    title: 'SEO Best Practices for AI-Generated Apps',
+    excerpt:
+      'AI builders ship fast — but do your generated apps rank? Follow these SEO best practices to make AI-generated apps crawlable, indexable, and discoverable.',
+    category: 'Best Practices',
+    keywords: [
+      'AI app builder SEO',
+      'SEO for AI-generated apps',
+      'SEO best practices',
+      'structured data JSON-LD',
+      'indexable single page app',
+      'sitemap for web app',
+    ],
+    tags: ['SEO', 'Best Practices', 'JSON-LD', 'Sitemap', 'Structured data'],
+    readTimeMinutes: 7,
+    datePublished: '2026-04-20',
+    dateModified: '2026-08-01',
+    intro:
+      'Speed is only half the battle. If search engines cannot crawl and understand your AI-generated app, it will not rank. Here are the SEO fundamentals that make generated apps discoverable.',
+    sections: [
+      {
+        heading: 'Render content so crawlers can read it',
+        paragraphs: [
+          'Many AI builders produce purely client-rendered apps where the initial HTML is nearly empty and everything appears only after JavaScript runs. Crawlers can struggle with that. Prefer output that server-renders or statically generates your key marketing and content pages so the important text and links are in the initial HTML. AINative Builder favors indexable output for the pages that matter for discovery.',
+        ],
+      },
+      {
+        heading: 'Give every important page its own URL',
+        paragraphs: [
+          'Search engines index URLs, not tabs or modals. Each distinct piece of content — a template, a comparison, an article — should live at its own crawlable URL with a unique title and meta description. This is why AINative Builder generates individually indexable pages for templates, comparisons, and guides rather than hiding them behind client-side state.',
+        ],
+        bullets: [
+          'One URL per indexable piece of content',
+          'Unique <title> and meta description per page',
+          'A canonical URL to avoid duplicate-content dilution',
+        ],
+      },
+      {
+        heading: 'Add structured data (JSON-LD)',
+        paragraphs: [
+          'Structured data tells search engines exactly what a page is — an article, a FAQ, a product, a breadcrumb trail — and unlocks rich results. Emit JSON-LD for your content types. AINative Builder adds JSON-LD automatically (Article, FAQPage, BreadcrumbList, SoftwareApplication) so your generated pages are eligible for enhanced search listings without manual effort.',
+        ],
+      },
+      {
+        heading: 'Ship a sitemap and internal links',
+        paragraphs: [
+          'A sitemap helps crawlers discover every URL, and internal links spread authority and help both users and crawlers navigate. Make sure new content is added to your sitemap and cross-linked from related pages. AINative Builder maintains a sitemap and encourages internal linking between related content, so newly published pages are found quickly.',
+        ],
+        bullets: [
+          'Keep an up-to-date sitemap.xml',
+          'Cross-link related pages (e.g. related articles and templates)',
+          'Use descriptive anchor text, not "click here"',
+        ],
+      },
+    ],
+    faqs: [
+      {
+        question: 'Do AI-generated apps rank in search engines?',
+        answer:
+          'They can — but only if they are crawlable. Apps that render content server-side or statically, give each page a unique URL and metadata, emit structured data, and ship a sitemap are far more likely to be indexed and ranked. AINative Builder produces this kind of SEO-friendly output.',
+      },
+      {
+        question: 'What structured data should my app include?',
+        answer:
+          'Common, high-value types are Article for content, FAQPage for question-and-answer sections, BreadcrumbList for navigation, and SoftwareApplication for product pages. AINative Builder emits these as JSON-LD automatically.',
+      },
+      {
+        question: 'Why does each page need its own URL for SEO?',
+        answer:
+          'Search engines index URLs, not client-side tabs or modals. Giving every important piece of content a unique, crawlable URL with its own title and description is what lets it appear as a distinct result in search.',
+      },
+    ],
+  },
+]
+
+/** All guide slugs — used by generateStaticParams and the sitemap. */
+export const GUIDE_SLUGS = GUIDES.map((g) => g.slug)
+
+/** Look up a guide by its URL slug. */
+export function getGuideBySlug(slug: string): SeoGuide | undefined {
+  return GUIDES.find((g) => g.slug === slug)
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -109,6 +109,15 @@ export async function middleware(request: NextRequest) {
       return NextResponse.next()
     }
 
+    // Allow the blog/guides articles for anonymous users — the /guides index and
+    // each /guides/[slug] article target long-tail keywords ("how to build a
+    // SaaS with AI", "v0 vs Lovable vs AINative", "what is AX optimization") and
+    // MUST be crawlable/indexable without an account. Without this they
+    // 307→/login, which blocks indexing entirely.
+    if (pathname === '/guides' || pathname.startsWith('/guides/')) {
+      return NextResponse.next()
+    }
+
     // Allow preview routes for anonymous users
     if (pathname.startsWith('/preview/')) {
       return NextResponse.next()


### PR DESCRIPTION
Closes #35

## Summary
Adds a public, SEO-focused **/guides** blog/tutorials section with individually indexable long-form articles targeting long-tail keywords, following the same static-generation + JSON-LD pattern established by `/compare` (#171) and `/templates/[slug]` (#172).

### Articles shipped
- `how-to-build-a-saas-with-ai` — "how to build a SaaS with AI"
- `v0-vs-lovable-vs-ainative` — "v0 vs Lovable vs AINative"
- `what-is-ax-optimization` — "what is AX optimization"
- `ai-app-builder-seo-best-practices` — "SEO for AI-generated apps"

### What's included
- **`lib/data/seo-guides.ts`** — single source of truth for guide content (sections, FAQs, keywords, dates). Mirrors `seo-templates.ts`.
- **`app/guides/page.tsx`** — static index hub with `ItemList` JSON-LD, per-category badges, and cards linking each article.
- **`app/guides/[slug]/page.tsx`** — SSG article page (`generateStaticParams`, `dynamicParams = false`) with unique `<title>`/meta/canonical, OG `article` tags, `Article` + `FAQPage` + `BreadcrumbList` JSON-LD, related-article internal linking, and CTAs.
- **`app/sitemap.ts`** — emits `/guides` + one URL per article.
- **`middleware.ts`** — allows `/guides` and `/guides/*` for anonymous users so crawlers can index them (they previously would 307→/login).
- **`components/shared/app-header.tsx`** — adds an always-visible public **Guides** nav link.

## Test evidence
`pnpm test` — new suites pass; the only failures are **pre-existing** and unrelated (`__tests__/api/evidence.test.ts` missing `@/lib/db`, `agent-skill.service`, `prompt-generation`, `subagents`), verified failing identically on the base commit with these changes stashed.

```
✓ __tests__/lib/seo-guides.test.ts (12 tests)
✓ __tests__/lib/sitemap-guides.test.ts (3 tests)
Test Files  2 passed (2)
     Tests  15 passed (15)
```

## Build evidence
`pnpm build` — `✓ Compiled successfully`, `✓ Generating static pages (107/107)`:

```
├ ○ /guides                                          0 B         194 kB
├ ● /guides/[slug]                                   0 B         194 kB
├   ├ /guides/how-to-build-a-saas-with-ai
├   ├ /guides/v0-vs-lovable-vs-ainative
├   ├ /guides/what-is-ax-optimization
├   └ /guides/ai-app-builder-seo-best-practices
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)