### PR TITLE
feat(commands): wire Cmd+K command palette into app + client-safe data layer (#17)

### DIFF
--- a/__tests__/lib/built-in-commands.test.ts
+++ b/__tests__/lib/built-in-commands.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import { BUILT_IN_COMMANDS } from '@/lib/data/built-in-commands'
+
+/**
+ * Integrity checks for the built-in command library (Issue #17 acceptance
+ * criterion: "5+ built-in commands"). These guard against regressions where a
+ * command declares a template variable that is never referenced, or references
+ * a {{token}} that has no declared variable — either of which would break
+ * substitution at execution time.
+ */
+describe('BUILT_IN_COMMANDS', () => {
+  it('ships at least 5 built-in commands', () => {
+    expect(BUILT_IN_COMMANDS.length).toBeGreaterThanOrEqual(5)
+  })
+
+  it('every command has a non-empty template and a semver version', () => {
+    for (const cmd of BUILT_IN_COMMANDS) {
+      expect(typeof cmd.template).toBe('string')
+      expect(cmd.template.trim().length).toBeGreaterThan(0)
+      expect(cmd.version).toMatch(/^\d+\.\d+\.\d+$/)
+    }
+  })
+
+  it('every declared variable is referenced somewhere in its template', () => {
+    for (const cmd of BUILT_IN_COMMANDS) {
+      for (const variable of cmd.variables) {
+        expect(
+          cmd.template.includes(`{{${variable.name}`),
+          `variable "${variable.name}" is declared but never used in template`
+        ).toBe(true)
+      }
+    }
+  })
+
+  it('required select variables provide options', () => {
+    for (const cmd of BUILT_IN_COMMANDS) {
+      for (const variable of cmd.variables) {
+        if (variable.type === 'select' || variable.type === 'multiselect') {
+          expect(Array.isArray(variable.options)).toBe(true)
+          expect(variable.options!.length).toBeGreaterThan(0)
+        }
+      }
+    }
+  })
+
+  it('checkpoints have unique ids within a command', () => {
+    for (const cmd of BUILT_IN_COMMANDS) {
+      const ids = cmd.checkpoints.map((c) => c.id)
+      expect(new Set(ids).size).toBe(ids.length)
+    }
+  })
+
+  it('exposes required skills as string arrays', () => {
+    for (const cmd of BUILT_IN_COMMANDS) {
+      expect(Array.isArray(cmd.requiredSkills)).toBe(true)
+      for (const skill of cmd.requiredSkills) {
+        expect(typeof skill).toBe('string')
+      }
+    }
+  })
+})

--- a/__tests__/lib/command-client.test.ts
+++ b/__tests__/lib/command-client.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  buildSearchParams,
+  searchCommands,
+  getRecentCommands,
+  toggleFavorite,
+  executeCommand,
+} from '@/lib/client/command-client'
+import type { CommandSearchQuery } from '@/lib/types/agent-commands'
+
+/**
+ * Tests for the browser-safe command client (Issue #17). This module is the
+ * boundary between the Cmd+K palette and the /api/commands routes; it must
+ * never import the server DB service. We mock global fetch to assert the URLs,
+ * methods, and payloads it produces.
+ */
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: async () => body,
+  } as unknown as Response
+}
+
+describe('command-client', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  describe('buildSearchParams', () => {
+    it('omits empty / falsy values', () => {
+      const q: CommandSearchQuery = { query: '', sortBy: 'relevance' }
+      const qs = buildSearchParams(q)
+      expect(qs).toContain('sortBy=relevance')
+      expect(qs).not.toContain('query=')
+    })
+
+    it('serializes tags as a comma list and booleans as flags', () => {
+      const q: CommandSearchQuery = {
+        query: 'pr',
+        tags: ['git', 'ci'],
+        builtInOnly: true,
+        favoritesOnly: true,
+        limit: 5,
+        offset: 10,
+      }
+      const params = new URLSearchParams(buildSearchParams(q))
+      expect(params.get('query')).toBe('pr')
+      expect(params.get('tags')).toBe('git,ci')
+      expect(params.get('builtInOnly')).toBe('true')
+      expect(params.get('favoritesOnly')).toBe('true')
+      expect(params.get('limit')).toBe('5')
+      expect(params.get('offset')).toBe('10')
+    })
+  })
+
+  describe('searchCommands', () => {
+    it('GETs /api/commands with the query string and returns the result', async () => {
+      const result = { commands: [], total: 0, searchTime: 1, fuzzyMatch: true }
+      const fetchMock = vi.mocked(fetch)
+      fetchMock.mockResolvedValue(jsonResponse(result))
+
+      const out = await searchCommands({ query: 'pr', sortBy: 'relevance' })
+
+      expect(out).toEqual(result)
+      const [url, init] = fetchMock.mock.calls[0]
+      expect(String(url)).toMatch(/^\/api\/commands\?/)
+      expect(String(url)).toContain('query=pr')
+      expect(init?.method).toBe('GET')
+    })
+
+    it('throws with the server error message on a non-ok response', async () => {
+      vi.mocked(fetch).mockResolvedValue(
+        jsonResponse({ error: 'Unauthorized' }, false, 401)
+      )
+      await expect(searchCommands({ query: 'x' })).rejects.toThrow('Unauthorized')
+    })
+  })
+
+  describe('getRecentCommands', () => {
+    it('GETs /api/commands/recent and unwraps the commands array', async () => {
+      const fetchMock = vi.mocked(fetch)
+      fetchMock.mockResolvedValue(jsonResponse({ commands: [{ id: 1 }] }))
+
+      const out = await getRecentCommands(5)
+
+      expect(out).toEqual([{ id: 1 }])
+      const [url] = fetchMock.mock.calls[0]
+      expect(String(url)).toBe('/api/commands/recent?limit=5')
+    })
+
+    it('defaults to an empty array when commands is missing', async () => {
+      vi.mocked(fetch).mockResolvedValue(jsonResponse({}))
+      const out = await getRecentCommands()
+      expect(out).toEqual([])
+    })
+  })
+
+  describe('toggleFavorite', () => {
+    it('POSTs to the favorite endpoint and returns the new state', async () => {
+      const fetchMock = vi.mocked(fetch)
+      fetchMock.mockResolvedValue(jsonResponse({ isFavorite: true }))
+
+      const out = await toggleFavorite('cmd-123')
+
+      expect(out).toBe(true)
+      const [url, init] = fetchMock.mock.calls[0]
+      expect(String(url)).toBe('/api/commands/cmd-123/favorite')
+      expect(init?.method).toBe('POST')
+    })
+  })
+
+  describe('executeCommand', () => {
+    it('POSTs variable values and chat context to the execute endpoint', async () => {
+      const state = { status: 'completed' }
+      const fetchMock = vi.mocked(fetch)
+      fetchMock.mockResolvedValue(jsonResponse(state))
+
+      const out = await executeCommand('cmd-9', { baseBranch: 'main' }, { chatId: 'chat-1' })
+
+      expect(out).toEqual(state)
+      const [url, init] = fetchMock.mock.calls[0]
+      expect(String(url)).toBe('/api/commands/cmd-9/execute')
+      expect(init?.method).toBe('POST')
+      const payload = JSON.parse(String(init?.body))
+      expect(payload.variableValues).toEqual({ baseBranch: 'main' })
+      expect(payload.chatId).toBe('chat-1')
+    })
+
+    it('surfaces validation errors as a thrown error', async () => {
+      vi.mocked(fetch).mockResolvedValue(
+        jsonResponse({ error: 'Validation failed' }, false, 400)
+      )
+      await expect(
+        executeCommand('cmd-9', {})
+      ).rejects.toThrow('Validation failed')
+    })
+  })
+})

--- a/__tests__/lib/command-variables.test.ts
+++ b/__tests__/lib/command-variables.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import {
+  substituteVariables,
+  validateVariables,
+} from '@/lib/validation/command-variables'
+import type { CommandVariable } from '@/lib/types/agent-commands'
+
+/**
+ * The pure validation/substitution module is shared by both the server
+ * AgentCommandService and the client variable-prompt dialog (Issue #17). It is
+ * the browser-safe replacement that keeps the Drizzle/postgres driver out of
+ * the client bundle, so it is tested independently of the service.
+ */
+describe('command-variables (shared pure module)', () => {
+  describe('substituteVariables', () => {
+    it('substitutes and coerces values, leaving unknown tokens intact', () => {
+      const out = substituteVariables('{{a}}-{{n}}-{{missing}}', { a: 'x', n: 3 })
+      expect(out).toBe('x-3-{{missing}}')
+    })
+  })
+
+  describe('validateVariables', () => {
+    it('flags a missing required variable', () => {
+      const vars: CommandVariable[] = [
+        { name: 'title', label: 'Title', type: 'text', required: true },
+      ]
+      const result = validateVariables(vars, {})
+      expect(result.valid).toBe(false)
+      expect(result.errors.title).toContain('required')
+    })
+
+    it('passes a fully valid multiselect', () => {
+      const vars: CommandVariable[] = [
+        {
+          name: 'checks',
+          label: 'Checks',
+          type: 'multiselect',
+          required: false,
+          options: [
+            { label: 'lint', value: 'lint' },
+            { label: 'test', value: 'test' },
+          ],
+        },
+      ]
+      expect(validateVariables(vars, { checks: ['lint', 'test'] }).valid).toBe(true)
+      expect(validateVariables(vars, { checks: ['nope'] }).valid).toBe(false)
+    })
+  })
+})

--- a/__tests__/services/agent-command.service.test.ts
+++ b/__tests__/services/agent-command.service.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { AgentCommandService, getCommandService } from '@/lib/services/agent-command.service'
+import type { CommandVariable } from '@/lib/types/agent-commands'
+
+/**
+ * Unit tests for the pure (non-DB) logic of AgentCommandService:
+ * template variable substitution and variable validation. These are the
+ * building blocks the command palette (Issue #17) relies on before it ever
+ * touches the database, so they are exercised in isolation.
+ */
+describe('AgentCommandService', () => {
+  let service: AgentCommandService
+
+  beforeEach(() => {
+    service = new AgentCommandService()
+  })
+
+  describe('getCommandService', () => {
+    it('returns a singleton instance', () => {
+      const a = getCommandService()
+      const b = getCommandService()
+      expect(a).toBe(b)
+      expect(a).toBeInstanceOf(AgentCommandService)
+    })
+  })
+
+  describe('substituteVariables', () => {
+    it('replaces a single {{variable}} token', () => {
+      const result = service.substituteVariables('Base branch: {{baseBranch}}', {
+        baseBranch: 'main',
+      })
+      expect(result).toBe('Base branch: main')
+    })
+
+    it('replaces multiple distinct variables', () => {
+      const template = 'PR "{{prTitle}}" targeting {{baseBranch}}'
+      const result = service.substituteVariables(template, {
+        prTitle: 'Add new feature',
+        baseBranch: 'main',
+      })
+      expect(result).toContain('Add new feature')
+      expect(result).toContain('main')
+      expect(result).toBe('PR "Add new feature" targeting main')
+    })
+
+    it('replaces every occurrence of the same variable (global)', () => {
+      const result = service.substituteVariables('{{name}} = {{name}}', {
+        name: 'x',
+      })
+      expect(result).toBe('x = x')
+    })
+
+    it('tolerates surrounding whitespace inside the braces', () => {
+      const result = service.substituteVariables('Hello {{  who  }}', {
+        who: 'world',
+      })
+      expect(result).toBe('Hello world')
+    })
+
+    it('coerces non-string values to strings', () => {
+      const result = service.substituteVariables('n={{count}} b={{flag}}', {
+        count: 42,
+        flag: true,
+      })
+      expect(result).toBe('n=42 b=true')
+    })
+
+    it('leaves unknown tokens untouched', () => {
+      const result = service.substituteVariables('{{a}} {{b}}', { a: '1' })
+      expect(result).toBe('1 {{b}}')
+    })
+  })
+
+  describe('validateVariables', () => {
+    const requiredText: CommandVariable = {
+      name: 'prTitle',
+      label: 'PR Title',
+      type: 'text',
+      required: true,
+    }
+
+    it('passes when all required values are present', () => {
+      const result = service.validateVariables([requiredText], {
+        prTitle: 'A valid title',
+      })
+      expect(result.valid).toBe(true)
+      expect(result.errors).toEqual({})
+    })
+
+    it('reports a missing required value', () => {
+      const result = service.validateVariables([requiredText], {})
+      expect(result.valid).toBe(false)
+      expect(result.errors.prTitle).toContain('required')
+    })
+
+    it('treats empty string as missing for required fields', () => {
+      const result = service.validateVariables([requiredText], { prTitle: '' })
+      expect(result.valid).toBe(false)
+      expect(result.errors.prTitle).toBeDefined()
+    })
+
+    it('validates number types', () => {
+      const numberVar: CommandVariable = {
+        name: 'count',
+        label: 'Count',
+        type: 'number',
+        required: false,
+      }
+      expect(service.validateVariables([numberVar], { count: 5 }).valid).toBe(true)
+      const bad = service.validateVariables([numberVar], { count: 'nope' })
+      expect(bad.valid).toBe(false)
+      expect(bad.errors.count).toContain('number')
+    })
+
+    it('validates select options', () => {
+      const selectVar: CommandVariable = {
+        name: 'branch',
+        label: 'Branch',
+        type: 'select',
+        required: true,
+        options: [
+          { label: 'main', value: 'main' },
+          { label: 'develop', value: 'develop' },
+        ],
+      }
+      expect(service.validateVariables([selectVar], { branch: 'main' }).valid).toBe(true)
+      const bad = service.validateVariables([selectVar], { branch: 'nonexistent' })
+      expect(bad.valid).toBe(false)
+      expect(bad.errors.branch).toBeDefined()
+    })
+
+    it('validates url types', () => {
+      const urlVar: CommandVariable = {
+        name: 'link',
+        label: 'Link',
+        type: 'url',
+        required: false,
+      }
+      expect(service.validateVariables([urlVar], { link: 'https://x.com' }).valid).toBe(true)
+      expect(service.validateVariables([urlVar], { link: 'not a url' }).valid).toBe(false)
+    })
+
+    it('enforces custom regex validation with the provided message', () => {
+      const regexVar: CommandVariable = {
+        name: 'prTitle',
+        label: 'PR Title',
+        type: 'text',
+        required: true,
+        validation: '^.{10,}$',
+        validationMessage: 'PR title must be at least 10 characters',
+      }
+      const bad = service.validateVariables([regexVar], { prTitle: 'short' })
+      expect(bad.valid).toBe(false)
+      expect(bad.errors.prTitle).toBe('PR title must be at least 10 characters')
+
+      const ok = service.validateVariables([regexVar], { prTitle: 'a long enough title' })
+      expect(ok.valid).toBe(true)
+    })
+
+    it('skips validation for optional values that are omitted', () => {
+      const optional: CommandVariable = {
+        name: 'notes',
+        label: 'Notes',
+        type: 'text',
+        required: false,
+        validation: '^.{5,}$',
+      }
+      const result = service.validateVariables([optional], {})
+      expect(result.valid).toBe(true)
+    })
+  })
+})

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import { StreamingProvider } from '@/contexts/streaming-context'
 import { SWRProvider } from '@/components/providers/swr-provider'
 import { SessionProvider } from '@/components/providers/session-provider'
 import { Toaster } from '@/components/ui/toaster'
+import { CommandPaletteProvider } from '@/components/providers/command-palette-provider'
 import GoogleAnalytics from '@/components/analytics/google-analytics'
 
 const poppins = Poppins({
@@ -198,6 +199,7 @@ export default function RootLayout({
                 {children}
               </div>
               <Toaster />
+              <CommandPaletteProvider />
             </StreamingProvider>
           </SWRProvider>
         </SessionProvider>

--- a/components/command-palette.tsx
+++ b/components/command-palette.tsx
@@ -15,7 +15,7 @@
  */
 
 import * as React from 'react'
-import { useEffect, useState, useCallback, useMemo } from 'react'
+import { useEffect, useState } from 'react'
 import {
   CommandDialog,
   CommandEmpty,
@@ -41,7 +41,7 @@ import {
   Heart
 } from 'lucide-react'
 import { AgentCommand, CommandSearchQuery } from '@/lib/types/agent-commands'
-import { getCommandService } from '@/lib/services/agent-command.service'
+import * as commandClient from '@/lib/client/command-client'
 import { cn } from '@/lib/utils'
 import { VariablePromptDialog } from './command-variable-prompt'
 import { CommandProgressTracker } from './command-progress-tracker'
@@ -76,8 +76,6 @@ export function CommandPalette({
   const [showVariablePrompt, setShowVariablePrompt] = useState(false)
   const [showProgress, setShowProgress] = useState(false)
 
-  const commandService = useMemo(() => getCommandService(), [])
-
   // Load recent commands on mount
   useEffect(() => {
     if (open && userId) {
@@ -94,7 +92,7 @@ export function CommandPalette({
 
   const loadRecentCommands = async () => {
     try {
-      const recent = await commandService.getRecentCommands(userId, 5)
+      const recent = await commandClient.getRecentCommands(5)
       setRecentCommands(recent)
     } catch (error) {
       console.error('Failed to load recent commands:', error)
@@ -110,7 +108,7 @@ export function CommandPalette({
         limit: 20,
       }
 
-      const result = await commandService.searchCommands(userId, query)
+      const result = await commandClient.searchCommands(query)
       setCommands(result.commands)
     } catch (error) {
       console.error('Failed to search commands:', error)
@@ -147,13 +145,12 @@ export function CommandPalette({
       // Show progress tracker
       setShowProgress(true)
 
-      // Execute the command
-      const state = await commandService.executeCommand(command, {
-        command,
+      // Execute the command via the API
+      const state = await commandClient.executeCommand(
+        command.metadata.id,
         variableValues,
-        userId,
-        chatId,
-      })
+        { chatId }
+      )
 
       // Command execution complete
       console.log('Command executed:', state)
@@ -165,7 +162,7 @@ export function CommandPalette({
   const toggleFavorite = async (command: AgentCommand, e: React.MouseEvent) => {
     e.stopPropagation()
     try {
-      const isFavorite = await commandService.toggleFavorite(command.metadata.id, userId)
+      const isFavorite = await commandClient.toggleFavorite(command.metadata.id)
 
       // Update local state
       setCommands(prevCommands =>

--- a/components/command-variable-prompt.tsx
+++ b/components/command-variable-prompt.tsx
@@ -38,7 +38,7 @@ import { Badge } from '@/components/ui/badge'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { AlertCircle } from 'lucide-react'
 import { AgentCommand, CommandVariable } from '@/lib/types/agent-commands'
-import { getCommandService } from '@/lib/services/agent-command.service'
+import { validateVariables } from '@/lib/validation/command-variables'
 
 interface VariablePromptDialogProps {
   open: boolean
@@ -60,8 +60,6 @@ export function VariablePromptDialog({
   const [values, setValues] = useState<Record<string, any>>(initialValues)
   const [errors, setErrors] = useState<Record<string, string>>({})
   const [isSubmitting, setIsSubmitting] = useState(false)
-
-  const commandService = getCommandService()
 
   // Initialize with default values
   useEffect(() => {
@@ -91,7 +89,7 @@ export function VariablePromptDialog({
     setIsSubmitting(true)
 
     // Validate
-    const validation = commandService.validateVariables(command.variables, values)
+    const validation = validateVariables(command.variables, values)
 
     if (!validation.valid) {
       setErrors(validation.errors)

--- a/components/providers/command-palette-provider.tsx
+++ b/components/providers/command-palette-provider.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+/**
+ * Command Palette Provider
+ *
+ * Globally mounts the Cmd+K command palette (Issue #17) and wires it to the
+ * authenticated session. Renders nothing for signed-out visitors so public
+ * marketing pages are unaffected.
+ *
+ * The palette itself owns the Cmd+K / Ctrl+K key handler; this provider just
+ * supplies open state and the current user id.
+ */
+
+import { useState } from 'react'
+import { useSession } from 'next-auth/react'
+import { CommandPalette } from '@/components/command-palette'
+
+export function CommandPaletteProvider() {
+  const { data: session, status } = useSession()
+  const [open, setOpen] = useState(false)
+
+  // Only mount for authenticated users. Command execution requires a user id
+  // and hits authenticated API routes, so there is nothing to show otherwise.
+  const userId = session?.user?.id
+  if (status !== 'authenticated' || !userId) {
+    return null
+  }
+
+  return (
+    <CommandPalette open={open} onOpenChange={setOpen} userId={userId} />
+  )
+}

--- a/lib/client/command-client.ts
+++ b/lib/client/command-client.ts
@@ -1,0 +1,111 @@
+/**
+ * Command Client (browser-safe)
+ *
+ * Thin fetch wrapper around the /api/commands REST endpoints for use in
+ * client components. The command palette must NOT import the server-side
+ * `agent-command.service`, because that pulls Drizzle + the postgres driver
+ * into the browser bundle (breaking `next build` and runtime). All data
+ * access from the UI goes through this module instead.
+ *
+ * Issue #17 — Command Palette for Agent Workflows.
+ */
+
+import type {
+  AgentCommand,
+  CommandSearchQuery,
+  CommandSearchResult,
+  CommandExecutionState,
+} from '@/lib/types/agent-commands'
+
+/**
+ * Build a query string from a CommandSearchQuery, omitting empty values.
+ */
+export function buildSearchParams(query: CommandSearchQuery): string {
+  const params = new URLSearchParams()
+
+  if (query.query) params.set('query', query.query)
+  if (query.category) params.set('category', String(query.category))
+  if (query.tags && query.tags.length > 0) params.set('tags', query.tags.join(','))
+  if (query.authorId) params.set('authorId', query.authorId)
+  if (query.builtInOnly) params.set('builtInOnly', 'true')
+  if (query.teamOnly) params.set('teamOnly', 'true')
+  if (query.favoritesOnly) params.set('favoritesOnly', 'true')
+  if (query.sortBy) params.set('sortBy', String(query.sortBy))
+  if (typeof query.limit === 'number') params.set('limit', String(query.limit))
+  if (typeof query.offset === 'number') params.set('offset', String(query.offset))
+
+  return params.toString()
+}
+
+async function parseJson<T>(res: Response): Promise<T> {
+  if (!res.ok) {
+    let message = `Request failed with status ${res.status}`
+    try {
+      const body = await res.json()
+      if (body?.error) message = body.error
+    } catch {
+      // ignore non-JSON error bodies
+    }
+    throw new Error(message)
+  }
+  return (await res.json()) as T
+}
+
+/**
+ * Search / list commands via GET /api/commands.
+ */
+export async function searchCommands(
+  query: CommandSearchQuery
+): Promise<CommandSearchResult> {
+  const qs = buildSearchParams(query)
+  const res = await fetch(`/api/commands${qs ? `?${qs}` : ''}`, {
+    method: 'GET',
+    headers: { Accept: 'application/json' },
+  })
+  return parseJson<CommandSearchResult>(res)
+}
+
+/**
+ * Fetch recently executed commands via GET /api/commands/recent.
+ */
+export async function getRecentCommands(limit = 10): Promise<AgentCommand[]> {
+  const res = await fetch(`/api/commands/recent?limit=${limit}`, {
+    method: 'GET',
+    headers: { Accept: 'application/json' },
+  })
+  const data = await parseJson<{ commands: AgentCommand[] }>(res)
+  return data.commands ?? []
+}
+
+/**
+ * Toggle favorite status via POST /api/commands/[id]/favorite.
+ * Returns the new favorite state.
+ */
+export async function toggleFavorite(commandId: string): Promise<boolean> {
+  const res = await fetch(`/api/commands/${commandId}/favorite`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+  })
+  const data = await parseJson<{ isFavorite: boolean }>(res)
+  return data.isFavorite
+}
+
+/**
+ * Execute a command via POST /api/commands/[id]/execute.
+ */
+export async function executeCommand(
+  commandId: string,
+  variableValues: Record<string, unknown>,
+  options?: { chatId?: string; gitContext?: unknown }
+): Promise<CommandExecutionState> {
+  const res = await fetch(`/api/commands/${commandId}/execute`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      variableValues,
+      chatId: options?.chatId,
+      gitContext: options?.gitContext,
+    }),
+  })
+  return parseJson<CommandExecutionState>(res)
+}

--- a/lib/services/agent-command.service.ts
+++ b/lib/services/agent-command.service.ts
@@ -39,6 +39,10 @@ import {
 } from '@/lib/types/agent-commands';
 import { eq, and, or, desc, asc, sql, inArray } from 'drizzle-orm';
 import { getSkillService } from './agent-skill.service';
+import {
+  substituteVariables as substituteVariablesPure,
+  validateVariables as validateVariablesPure,
+} from '@/lib/validation/command-variables';
 
 /**
  * Fuzzy search scoring algorithm
@@ -373,14 +377,7 @@ export class AgentCommandService {
    * Substitute variables in template
    */
   substituteVariables(template: string, values: Record<string, any>): string {
-    let result = template;
-
-    for (const [key, value] of Object.entries(values)) {
-      const regex = new RegExp(`\\{\\{\\s*${key}\\s*\\}\\}`, 'g');
-      result = result.replace(regex, String(value));
-    }
-
-    return result;
+    return substituteVariablesPure(template, values);
   }
 
   /**
@@ -390,70 +387,7 @@ export class AgentCommandService {
     variables: CommandVariable[],
     values: Record<string, any>
   ): { valid: boolean; errors: Record<string, string> } {
-    const errors: Record<string, string> = {};
-
-    for (const variable of variables) {
-      const value = values[variable.name];
-
-      // Check required
-      if (variable.required && (value === undefined || value === null || value === '')) {
-        errors[variable.name] = `${variable.label} is required`;
-        continue;
-      }
-
-      // Skip validation if not provided and not required
-      if (value === undefined || value === null) continue;
-
-      // Type validation
-      switch (variable.type) {
-        case 'number':
-          if (isNaN(Number(value))) {
-            errors[variable.name] = `${variable.label} must be a number`;
-          }
-          break;
-        case 'boolean':
-          if (typeof value !== 'boolean') {
-            errors[variable.name] = `${variable.label} must be true or false`;
-          }
-          break;
-        case 'select':
-          if (variable.options && !variable.options.some((opt) => opt.value === value)) {
-            errors[variable.name] = `${variable.label} must be one of the available options`;
-          }
-          break;
-        case 'multiselect':
-          if (!Array.isArray(value)) {
-            errors[variable.name] = `${variable.label} must be an array`;
-          } else if (variable.options) {
-            const validValues = variable.options.map((opt) => opt.value);
-            const invalidValues = value.filter((v) => !validValues.includes(v));
-            if (invalidValues.length > 0) {
-              errors[variable.name] = `${variable.label} contains invalid values`;
-            }
-          }
-          break;
-        case 'url':
-          try {
-            new URL(String(value));
-          } catch {
-            errors[variable.name] = `${variable.label} must be a valid URL`;
-          }
-          break;
-      }
-
-      // Custom regex validation
-      if (variable.validation && typeof value === 'string') {
-        const regex = new RegExp(variable.validation);
-        if (!regex.test(value)) {
-          errors[variable.name] = variable.validationMessage || `${variable.label} is invalid`;
-        }
-      }
-    }
-
-    return {
-      valid: Object.keys(errors).length === 0,
-      errors,
-    };
+    return validateVariablesPure(variables, values);
   }
 
   /**

--- a/lib/validation/command-variables.ts
+++ b/lib/validation/command-variables.ts
@@ -1,0 +1,114 @@
+/**
+ * Command Variable Validation & Substitution (browser-safe)
+ *
+ * Pure helpers shared by the server-side AgentCommandService and the client
+ * command palette (Issue #17). This module has NO database or Node-only
+ * imports, so it is safe to bundle into client components (e.g. the variable
+ * prompt dialog) without dragging in Drizzle / the postgres driver.
+ */
+
+import type { CommandVariable } from '@/lib/types/agent-commands'
+
+export interface VariableValidationResult {
+  valid: boolean
+  errors: Record<string, string>
+}
+
+/**
+ * Substitute {{variable}} tokens in a template with provided values.
+ * Whitespace inside the braces is tolerated and all occurrences are replaced.
+ */
+export function substituteVariables(
+  template: string,
+  values: Record<string, unknown>
+): string {
+  let result = template
+
+  for (const [key, value] of Object.entries(values)) {
+    const regex = new RegExp(`\\{\\{\\s*${key}\\s*\\}\\}`, 'g')
+    result = result.replace(regex, String(value))
+  }
+
+  return result
+}
+
+/**
+ * Validate a set of variable values against their declared definitions.
+ */
+export function validateVariables(
+  variables: CommandVariable[],
+  values: Record<string, unknown>
+): VariableValidationResult {
+  const errors: Record<string, string> = {}
+
+  for (const variable of variables) {
+    const value = values[variable.name]
+
+    // Check required
+    if (
+      variable.required &&
+      (value === undefined || value === null || value === '')
+    ) {
+      errors[variable.name] = `${variable.label} is required`
+      continue
+    }
+
+    // Skip validation if not provided and not required
+    if (value === undefined || value === null) continue
+
+    // Type validation
+    switch (variable.type) {
+      case 'number':
+        if (isNaN(Number(value))) {
+          errors[variable.name] = `${variable.label} must be a number`
+        }
+        break
+      case 'boolean':
+        if (typeof value !== 'boolean') {
+          errors[variable.name] = `${variable.label} must be true or false`
+        }
+        break
+      case 'select':
+        if (
+          variable.options &&
+          !variable.options.some((opt) => opt.value === value)
+        ) {
+          errors[variable.name] =
+            `${variable.label} must be one of the available options`
+        }
+        break
+      case 'multiselect':
+        if (!Array.isArray(value)) {
+          errors[variable.name] = `${variable.label} must be an array`
+        } else if (variable.options) {
+          const validValues = variable.options.map((opt) => opt.value)
+          const invalidValues = value.filter((v) => !validValues.includes(v))
+          if (invalidValues.length > 0) {
+            errors[variable.name] = `${variable.label} contains invalid values`
+          }
+        }
+        break
+      case 'url':
+        try {
+          new URL(String(value))
+        } catch {
+          errors[variable.name] = `${variable.label} must be a valid URL`
+        }
+        break
+    }
+
+    // Custom regex validation
+    if (variable.validation && typeof value === 'string') {
+      const regex = new RegExp(variable.validation)
+      if (!regex.test(value)) {
+        errors[variable.name] =
+          variable.validationMessage || `${variable.label} is invalid`
+      }
+    }
+  }
+
+  return {
+    valid: Object.keys(errors).length === 0,
+    errors,
+  }
+}


### PR DESCRIPTION
## Summary

Makes the **Cmd+K Command Palette for Agent Workflows** (Issue #17) actually functional and shippable.

The backend for this feature already existed on `main` (the `AgentCommandService`, the `/api/commands` REST routes, the `agent_commands` / `command_favorites` / `command_executions` schema, and 5 built-in commands), along with the palette UI components. But it was **broken and unmounted**:

- `command-palette.tsx` and `command-variable-prompt.tsx` (both `"use client"`) imported the server-side `getCommandService()`, which pulls Drizzle + the `postgres` driver into the browser bundle. This **broke `next build`** (`Module not found: Can't resolve 'tls'`, and `'server-only' cannot be imported from a Client Component`) and would have failed at runtime.
- The palette was never rendered anywhere, so Cmd+K did nothing.

### What changed

- **`lib/client/command-client.ts`** (new) — browser-safe `fetch` wrapper over the `/api/commands` routes (`searchCommands`, `getRecentCommands`, `toggleFavorite`, `executeCommand`, `buildSearchParams`). This is the correct client boundary.
- **`lib/validation/command-variables.ts`** (new) — pure `substituteVariables` / `validateVariables` with **no DB imports**, shared by both the server service and the client dialog (single source of truth).
- **`components/command-palette.tsx`** / **`components/command-variable-prompt.tsx`** — rewired to use the client / validation modules instead of the server service.
- **`lib/services/agent-command.service.ts`** — its `substituteVariables` / `validateVariables` now delegate to the shared pure module (behavior unchanged).
- **`components/providers/command-palette-provider.tsx`** (new) + **`app/layout.tsx`** — mounts the palette globally for authenticated users so **Cmd+K works**; renders nothing for signed-out visitors (public marketing pages unaffected).

### Acceptance criteria touched

- ✅ Command palette opens with Cmd+K (now actually mounted)
- ✅ Fuzzy search, variable prompting, skill auto-loading, progress tracking, 5+ built-in commands, pre-condition validation (existing backend, now reachable from a working UI)

## Test evidence

New vitest coverage (33 tests, all passing):

- `__tests__/services/agent-command.service.test.ts` — template substitution + variable validation (required/number/select/url/regex)
- `__tests__/lib/command-variables.test.ts` — shared pure module
- `__tests__/lib/command-client.test.ts` — fetch wrapper URLs/methods/payloads (mocked `fetch`)
- `__tests__/lib/built-in-commands.test.ts` — built-in command data integrity (every declared variable is referenced, unique checkpoint ids, ≥5 commands)

```
$ pnpm exec vitest run __tests__/services/agent-command.service.test.ts \
    __tests__/lib/command-client.test.ts \
    __tests__/lib/built-in-commands.test.ts \
    __tests__/lib/command-variables.test.ts
 ✓ __tests__/lib/command-variables.test.ts (3 tests)
 ✓ __tests__/lib/built-in-commands.test.ts (6 tests)
 ✓ __tests__/lib/command-client.test.ts (9 tests)
 ✓ __tests__/services/agent-command.service.test.ts (15 tests)
 Test Files  4 passed (4)
      Tests  33 passed (33)
```

Full suite: `pnpm test` → **458 passed**, 30 skipped. The 10 remaining failures **pre-date this branch** and are unrelated (verified by stashing this diff and re-running): `evidence.test.ts` uses `require('@/lib/db')` which is null without `POSTGRES_URL`, one flaky timing assertion in `agent-skill.service.test.ts`, and `subagents.test.ts` needs an API key.

Build:

```
$ pnpm build
 ✓ Compiled successfully in 77s
 ✓ Generating static pages (107/107)
```

(Previously failed to compile due to the client→server DB import; now green.)
