### PR TITLE
feat(enforcement): Rule Enforcement Framework — deterministic auto-fix, settings UI, tests (#18)

### DIFF
--- a/__tests__/lib/built-in-rules.test.ts
+++ b/__tests__/lib/built-in-rules.test.ts
@@ -1,0 +1,480 @@
+/**
+ * Unit tests for the built-in enforcement rules.
+ *
+ * Covers every built-in rule's `check()` behaviour (pass + fail paths) and the
+ * rule-level `autoFix()` for the two auto-fixable rules.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  NO_AI_ATTRIBUTION_RULE,
+  COMMIT_MESSAGE_FORMAT_RULE,
+  BRANCH_NAMING_RULE,
+  NO_ROOT_MD_FILES_RULE,
+  NO_BACKEND_SCRIPTS_RULE,
+  DOCS_IN_SUBDIRS_RULE,
+  MANDATORY_TEST_EXECUTION_RULE,
+  MIN_COVERAGE_80_RULE,
+  NO_SECRETS_IN_CODE_RULE,
+  NO_PII_IN_LOGS_RULE,
+  INPUT_VALIDATION_RULE,
+  NO_CONSOLE_LOG_RULE,
+  USE_SCHEMA_SYNC_RULE,
+  getAllBuiltInRules,
+} from '@/lib/services/built-in-rules';
+import { RULE_IDS } from '@/lib/types/enforcement-rules';
+import type { AgentAction, RuleContext } from '@/lib/types/enforcement-rules';
+
+function makeAction(
+  type: RuleContext,
+  data: AgentAction['data']
+): AgentAction {
+  return {
+    type,
+    data,
+    userId: 'user-1',
+    projectId: 'project-1',
+    timestamp: new Date(),
+  };
+}
+
+describe('getAllBuiltInRules', () => {
+  it('returns at least 10 rules (acceptance criteria)', () => {
+    const rules = getAllBuiltInRules();
+    expect(rules.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it('every rule has a unique id', () => {
+    const rules = getAllBuiltInRules();
+    const ids = rules.map((r) => r.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('covers git, file-placement, testing, security categories', () => {
+    const categories = new Set(getAllBuiltInRules().map((r) => r.category));
+    expect(categories).toContain('git');
+    expect(categories).toContain('file-placement');
+    expect(categories).toContain('testing');
+    expect(categories).toContain('security');
+  });
+
+  it('every rule.check runs within the 50ms per-rule performance target', async () => {
+    const action = makeAction('commit', {
+      commitMessage: 'feat(auth): add login',
+      files: ['app/x.ts'],
+      testOutput: '95% coverage',
+    });
+    for (const rule of getAllBuiltInRules()) {
+      const result = await rule.check(action);
+      expect(result.duration).toBeLessThan(50);
+    }
+  });
+});
+
+describe('NO_AI_ATTRIBUTION_RULE', () => {
+  it('blocks a commit message containing "Claude"', async () => {
+    const action = makeAction('commit', {
+      commitMessage: 'Add feature\n\nGenerated with Claude',
+    });
+    const result = await NO_AI_ATTRIBUTION_RULE.check(action);
+    expect(result.passed).toBe(false);
+    expect(result.violations.length).toBeGreaterThan(0);
+    expect(result.violations[0].level).toBe('error');
+    expect(result.violations[0].autoFixable).toBe(true);
+  });
+
+  it('blocks Anthropic / ChatGPT / Copilot attribution', async () => {
+    for (const term of ['Anthropic', 'ChatGPT', 'GitHub Copilot']) {
+      const result = await NO_AI_ATTRIBUTION_RULE.check(
+        makeAction('commit', { commitMessage: `fix: bug\n\n${term}` })
+      );
+      expect(result.passed).toBe(false);
+    }
+  });
+
+  it('passes a clean commit message', async () => {
+    const result = await NO_AI_ATTRIBUTION_RULE.check(
+      makeAction('commit', { commitMessage: 'feat(auth): add login' })
+    );
+    expect(result.passed).toBe(true);
+    expect(result.violations).toHaveLength(0);
+  });
+
+  it('checks PR title and description too', async () => {
+    const result = await NO_AI_ATTRIBUTION_RULE.check(
+      makeAction('pr-create', {
+        prTitle: 'Clean title',
+        prDescription: 'Body\n\nCo-Authored-By: Claude',
+      })
+    );
+    expect(result.passed).toBe(false);
+  });
+
+  it('autoFix strips attribution from commit message', async () => {
+    const action = makeAction('commit', {
+      commitMessage: 'Add feature\n\nCo-Authored-By: Claude',
+    });
+    const fixed = await NO_AI_ATTRIBUTION_RULE.autoFix!(action);
+    expect(fixed.data.commitMessage).not.toContain('Claude');
+  });
+
+  it('autoFix rewrites "Generated with Claude" to AINative branding', async () => {
+    const action = makeAction('commit', {
+      commitMessage: 'Add feature\n\nGenerated with Claude',
+    });
+    const fixed = await NO_AI_ATTRIBUTION_RULE.autoFix!(action);
+    expect(fixed.data.commitMessage).toContain('Built by AINative');
+    expect(fixed.data.commitMessage).not.toContain('Claude');
+  });
+
+  it('autoFix does not mutate the original action', async () => {
+    const original = 'Body\n\nGenerated with Claude';
+    const action = makeAction('commit', { commitMessage: original });
+    await NO_AI_ATTRIBUTION_RULE.autoFix!(action);
+    expect(action.data.commitMessage).toBe(original);
+  });
+});
+
+describe('COMMIT_MESSAGE_FORMAT_RULE', () => {
+  it('warns on non-conventional commit message', async () => {
+    const result = await COMMIT_MESSAGE_FORMAT_RULE.check(
+      makeAction('commit', { commitMessage: 'Added some stuff' })
+    );
+    expect(result.passed).toBe(false);
+    expect(result.violations[0].level).toBe('warning');
+  });
+
+  it('passes a conventional commit message', async () => {
+    const result = await COMMIT_MESSAGE_FORMAT_RULE.check(
+      makeAction('commit', {
+        commitMessage: 'feat(auth): add user authentication',
+      })
+    );
+    expect(result.passed).toBe(true);
+  });
+
+  it('warns when the first line exceeds 80 characters', async () => {
+    const longDesc = 'x'.repeat(90);
+    const result = await COMMIT_MESSAGE_FORMAT_RULE.check(
+      makeAction('commit', { commitMessage: `feat(x): ${longDesc}` })
+    );
+    expect(result.passed).toBe(false);
+  });
+});
+
+describe('BRANCH_NAMING_RULE', () => {
+  it('warns on a branch without a valid prefix', async () => {
+    const result = await BRANCH_NAMING_RULE.check(
+      makeAction('branch-create', { branch: 'my-new-feature' })
+    );
+    expect(result.passed).toBe(false);
+  });
+
+  it('passes a prefixed branch', async () => {
+    const result = await BRANCH_NAMING_RULE.check(
+      makeAction('branch-create', { branch: 'feature/user-auth' })
+    );
+    expect(result.passed).toBe(true);
+  });
+
+  it('allows protected branches (main/master/develop)', async () => {
+    for (const branch of ['main', 'master', 'develop']) {
+      const result = await BRANCH_NAMING_RULE.check(
+        makeAction('branch-create', { branch })
+      );
+      expect(result.passed).toBe(true);
+    }
+  });
+});
+
+describe('NO_ROOT_MD_FILES_RULE', () => {
+  it('blocks a .md file in the project root', async () => {
+    const result = await NO_ROOT_MD_FILES_RULE.check(
+      makeAction('file-create', { filePath: 'SUMMARY.md' })
+    );
+    expect(result.passed).toBe(false);
+    expect(result.violations[0].suggestion).toContain('docs/');
+  });
+
+  it('allows README.md and CODY.md in root', async () => {
+    for (const filePath of ['README.md', 'CODY.md']) {
+      const result = await NO_ROOT_MD_FILES_RULE.check(
+        makeAction('file-create', { filePath })
+      );
+      expect(result.passed).toBe(true);
+    }
+  });
+
+  it('allows .md files inside docs/', async () => {
+    const result = await NO_ROOT_MD_FILES_RULE.check(
+      makeAction('file-create', { filePath: 'docs/guides/setup.md' })
+    );
+    expect(result.passed).toBe(true);
+  });
+});
+
+describe('NO_BACKEND_SCRIPTS_RULE', () => {
+  it('blocks a .sh script in backend/', async () => {
+    const result = await NO_BACKEND_SCRIPTS_RULE.check(
+      makeAction('file-create', { filePath: 'backend/deploy.sh' })
+    );
+    expect(result.passed).toBe(false);
+  });
+
+  it('allows backend/start.sh', async () => {
+    const result = await NO_BACKEND_SCRIPTS_RULE.check(
+      makeAction('file-create', { filePath: 'backend/start.sh' })
+    );
+    expect(result.passed).toBe(true);
+  });
+
+  it('allows scripts in scripts/', async () => {
+    const result = await NO_BACKEND_SCRIPTS_RULE.check(
+      makeAction('file-create', { filePath: 'scripts/deploy/backend.sh' })
+    );
+    expect(result.passed).toBe(true);
+  });
+});
+
+describe('DOCS_IN_SUBDIRS_RULE', () => {
+  it('warns on a .md file directly in docs/', async () => {
+    const result = await DOCS_IN_SUBDIRS_RULE.check(
+      makeAction('file-create', { filePath: 'docs/API.md' })
+    );
+    expect(result.passed).toBe(false);
+    expect(result.violations[0].level).toBe('warning');
+  });
+
+  it('passes docs in a subdirectory', async () => {
+    const result = await DOCS_IN_SUBDIRS_RULE.check(
+      makeAction('file-create', { filePath: 'docs/api/endpoints.md' })
+    );
+    expect(result.passed).toBe(true);
+  });
+});
+
+describe('MANDATORY_TEST_EXECUTION_RULE', () => {
+  it('blocks a commit with code changes but no test output', async () => {
+    const result = await MANDATORY_TEST_EXECUTION_RULE.check(
+      makeAction('commit', { files: ['app/feature.ts'] })
+    );
+    expect(result.passed).toBe(false);
+    expect(result.violations[0].level).toBe('error');
+  });
+
+  it('passes when test output is included', async () => {
+    const result = await MANDATORY_TEST_EXECUTION_RULE.check(
+      makeAction('commit', {
+        files: ['app/feature.ts'],
+        testOutput: 'All tests passed',
+      })
+    );
+    expect(result.passed).toBe(true);
+  });
+
+  it('passes when only test files changed', async () => {
+    const result = await MANDATORY_TEST_EXECUTION_RULE.check(
+      makeAction('commit', { files: ['app/feature.test.ts'] })
+    );
+    expect(result.passed).toBe(true);
+  });
+});
+
+describe('MIN_COVERAGE_80_RULE', () => {
+  it('blocks when coverage is below 80%', async () => {
+    const result = await MIN_COVERAGE_80_RULE.check(
+      makeAction('commit', { testOutput: 'Total: 65% coverage' })
+    );
+    expect(result.passed).toBe(false);
+    expect(result.violations[0].message).toContain('65%');
+  });
+
+  it('passes when coverage is at or above 80%', async () => {
+    const result = await MIN_COVERAGE_80_RULE.check(
+      makeAction('commit', { testOutput: 'Total: 85% coverage' })
+    );
+    expect(result.passed).toBe(true);
+  });
+
+  it('passes when no coverage number is present', async () => {
+    const result = await MIN_COVERAGE_80_RULE.check(
+      makeAction('commit', { testOutput: 'tests passed' })
+    );
+    expect(result.passed).toBe(true);
+  });
+});
+
+describe('NO_SECRETS_IN_CODE_RULE', () => {
+  it('detects a Stripe live key', async () => {
+    const result = await NO_SECRETS_IN_CODE_RULE.check(
+      makeAction('file-edit', {
+        filePath: 'lib/pay.ts',
+        fileContent: 'const k = "sk_live_' + 'a'.repeat(30) + '"',
+      })
+    );
+    expect(result.passed).toBe(false);
+    expect(result.violations[0].level).toBe('error');
+  });
+
+  it('detects a hardcoded API key assignment', async () => {
+    const result = await NO_SECRETS_IN_CODE_RULE.check(
+      makeAction('file-edit', {
+        filePath: 'lib/x.ts',
+        fileContent: 'const API_KEY = "abcdefghij1234567890zzzz"',
+      })
+    );
+    expect(result.passed).toBe(false);
+  });
+
+  it('skips .env.example files', async () => {
+    const result = await NO_SECRETS_IN_CODE_RULE.check(
+      makeAction('file-edit', {
+        filePath: '.env.example',
+        fileContent: 'API_KEY="abcdefghij1234567890zzzz"',
+      })
+    );
+    expect(result.passed).toBe(true);
+  });
+
+  it('passes clean code using process.env', async () => {
+    const result = await NO_SECRETS_IN_CODE_RULE.check(
+      makeAction('file-edit', {
+        filePath: 'lib/x.ts',
+        fileContent: 'const apiKey = process.env.STRIPE_API_KEY',
+      })
+    );
+    expect(result.passed).toBe(true);
+  });
+});
+
+describe('NO_PII_IN_LOGS_RULE', () => {
+  it('detects PII in a console.log', async () => {
+    const result = await NO_PII_IN_LOGS_RULE.check(
+      makeAction('file-edit', {
+        filePath: 'lib/auth.ts',
+        fileContent: 'console.log("pw", user.password)',
+      })
+    );
+    expect(result.passed).toBe(false);
+  });
+
+  it('passes safe structured logging', async () => {
+    const result = await NO_PII_IN_LOGS_RULE.check(
+      makeAction('file-edit', {
+        filePath: 'lib/auth.ts',
+        fileContent: 'logger.info({ userId: user.id })',
+      })
+    );
+    expect(result.passed).toBe(true);
+  });
+});
+
+describe('INPUT_VALIDATION_RULE', () => {
+  it('warns on an API route using req.body without validation', async () => {
+    const result = await INPUT_VALIDATION_RULE.check(
+      makeAction('file-edit', {
+        filePath: 'app/api/users/route.ts',
+        fileContent: 'const { email } = req.body',
+      })
+    );
+    expect(result.passed).toBe(false);
+    expect(result.violations[0].level).toBe('warning');
+  });
+
+  it('passes when validation is present', async () => {
+    const result = await INPUT_VALIDATION_RULE.check(
+      makeAction('file-edit', {
+        filePath: 'app/api/users/route.ts',
+        fileContent: 'const { email } = schema.parse(req.body)',
+      })
+    );
+    expect(result.passed).toBe(true);
+  });
+
+  it('ignores non-API files', async () => {
+    const result = await INPUT_VALIDATION_RULE.check(
+      makeAction('file-edit', {
+        filePath: 'lib/util.ts',
+        fileContent: 'const x = req.body',
+      })
+    );
+    expect(result.passed).toBe(true);
+  });
+});
+
+describe('NO_CONSOLE_LOG_RULE', () => {
+  it('warns on console.log in production code', async () => {
+    const result = await NO_CONSOLE_LOG_RULE.check(
+      makeAction('file-edit', {
+        filePath: 'lib/x.ts',
+        fileContent: 'console.log("hi")',
+      })
+    );
+    expect(result.passed).toBe(false);
+    expect(result.violations[0].autoFixable).toBe(true);
+  });
+
+  it('skips test files', async () => {
+    const result = await NO_CONSOLE_LOG_RULE.check(
+      makeAction('file-edit', {
+        filePath: 'lib/x.test.ts',
+        fileContent: 'console.log("hi")',
+      })
+    );
+    expect(result.passed).toBe(true);
+  });
+
+  it('autoFix replaces console.log with logger.info', async () => {
+    const action = makeAction('file-edit', {
+      filePath: 'lib/x.ts',
+      fileContent: 'console.log("hi")',
+    });
+    const fixed = await NO_CONSOLE_LOG_RULE.autoFix!(action);
+    expect(fixed.data.fileContent).toContain('logger.info(');
+    expect(fixed.data.fileContent).not.toContain('console.log(');
+    // original untouched
+    expect(action.data.fileContent).toContain('console.log(');
+  });
+});
+
+describe('USE_SCHEMA_SYNC_RULE', () => {
+  it('blocks committing alembic migration files', async () => {
+    const result = await USE_SCHEMA_SYNC_RULE.check(
+      makeAction('commit', {
+        files: ['backend/alembic/versions/abc_add_table.py'],
+        commitMessage: 'chore: migration',
+      })
+    );
+    expect(result.passed).toBe(false);
+  });
+
+  it('blocks commit messages mentioning direct alembic commands', async () => {
+    const result = await USE_SCHEMA_SYNC_RULE.check(
+      makeAction('commit', {
+        files: [],
+        commitMessage: 'ran alembic upgrade head',
+      })
+    );
+    expect(result.passed).toBe(false);
+  });
+
+  it('passes when schema sync script is used', async () => {
+    const result = await USE_SCHEMA_SYNC_RULE.check(
+      makeAction('commit', {
+        files: ['scripts/sync-production-schema.py'],
+        commitMessage: 'chore(db): sync schema',
+      })
+    );
+    expect(result.passed).toBe(true);
+  });
+});
+
+describe('rule ID constants alignment', () => {
+  it('built-in rule ids match the RULE_IDS constants', () => {
+    const ids = getAllBuiltInRules().map((r) => r.id);
+    expect(ids).toContain(RULE_IDS.NO_AI_ATTRIBUTION);
+    expect(ids).toContain(RULE_IDS.NO_SECRETS_IN_CODE);
+    expect(ids).toContain(RULE_IDS.MANDATORY_TEST_EXECUTION);
+    expect(ids).toContain(RULE_IDS.NO_ROOT_MD_FILES);
+  });
+});

--- a/__tests__/services/rule-enforcement.service.test.ts
+++ b/__tests__/services/rule-enforcement.service.test.ts
@@ -1,0 +1,376 @@
+/**
+ * Unit tests for RuleEnforcementService.
+ *
+ * These mirror the acceptance-criteria Test Plan in issue #18 and additionally
+ * cover report aggregation, strict mode, and the deterministic auto-fix flow.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { RuleEnforcementService } from '@/lib/services/rule-enforcement.service';
+import { RULE_IDS } from '@/lib/types/enforcement-rules';
+import type {
+  AgentAction,
+  EnforcementConfig,
+  RuleContext,
+} from '@/lib/types/enforcement-rules';
+
+function makeAction(
+  type: RuleContext,
+  data: AgentAction['data']
+): AgentAction {
+  return {
+    type,
+    data,
+    userId: 'user-1',
+    projectId: 'project-1',
+    timestamp: new Date(),
+  };
+}
+
+function baseConfig(
+  overrides?: Partial<EnforcementConfig['settings']>
+): EnforcementConfig {
+  return {
+    projectId: 'project-1',
+    ruleSets: [],
+    ruleConfigs: [],
+    settings: {
+      autoFix: false,
+      strictMode: false,
+      continueOnError: true,
+      ...overrides,
+    },
+  };
+}
+
+describe('RuleEnforcementService', () => {
+  let service: RuleEnforcementService;
+
+  beforeEach(async () => {
+    service = new RuleEnforcementService();
+    await service.initialize(baseConfig());
+  });
+
+  it('loads built-in rules on initialize', () => {
+    expect(service.getRules().length).toBeGreaterThanOrEqual(10);
+    expect(service.getRule(RULE_IDS.NO_AI_ATTRIBUTION)).toBeDefined();
+  });
+
+  it('blocks third-party AI attribution', async () => {
+    const action = makeAction('commit', {
+      commitMessage: 'Add feature\n\nGenerated with Claude',
+    });
+    const report = await service.validateAction(action);
+    expect(report.passed).toBe(false);
+    const violations = report.results.flatMap((r) => r.violations);
+    expect(violations).toContainEqual(
+      expect.objectContaining({
+        ruleId: RULE_IDS.NO_AI_ATTRIBUTION,
+        level: 'error',
+      })
+    );
+  });
+
+  it('auto-fixes attribution violations', async () => {
+    const action = makeAction('commit', {
+      commitMessage: 'Add feature\n\nCo-Authored-By: Claude',
+    });
+    const report = await service.validateAction(action);
+    const violations = report.results.flatMap((r) => r.violations);
+    const fixed = await service.autoFixViolations(action, violations);
+    expect(fixed.data.commitMessage).not.toContain('Claude');
+  });
+
+  it('prevents root .md file creation with a docs/ suggestion', async () => {
+    const action = makeAction('file-create', { filePath: 'SUMMARY.md' });
+    const report = await service.validateAction(action);
+    expect(report.passed).toBe(false);
+    const violations = report.results.flatMap((r) => r.violations);
+    const rootMd = violations.find(
+      (v) => v.ruleId === RULE_IDS.NO_ROOT_MD_FILES
+    );
+    expect(rootMd?.suggestion).toContain('docs/');
+  });
+
+  it('detects secrets in code', async () => {
+    // Build the secret fixture at runtime so no scannable literal ships in
+    // source (satisfies push-protection) while still matching the rule regex
+    // /sk_live_[a-zA-Z0-9]{24,}/.
+    const fakeStripeKey = ['sk', 'live', 'x'.repeat(28)].join('_');
+    const action = makeAction('file-edit', {
+      filePath: 'lib/pay.ts',
+      fileContent: `const API_KEY = "${fakeStripeKey}"`,
+    });
+    const report = await service.validateAction(action);
+    expect(report.errorCount).toBeGreaterThan(0);
+  });
+
+  it('passes a clean, conventional, tested commit', async () => {
+    const action = makeAction('commit', {
+      commitMessage: 'feat(auth): add login',
+      files: ['app/login.ts'],
+      testOutput: 'All tests passed. 92% coverage',
+    });
+    const report = await service.validateAction(action);
+    expect(report.passed).toBe(true);
+    expect(report.errorCount).toBe(0);
+  });
+
+  describe('report aggregation', () => {
+    it('counts errors, warnings and info separately', async () => {
+      // "Added stuff" -> non-conventional (warning), no test output +
+      // code files (error). Attribution clean.
+      const action = makeAction('commit', {
+        commitMessage: 'Added stuff',
+        files: ['app/x.ts'],
+      });
+      const report = await service.validateAction(action);
+      expect(report.errorCount).toBeGreaterThanOrEqual(1); // mandatory tests
+      expect(report.warningCount).toBeGreaterThanOrEqual(1); // commit format
+    });
+
+    it('reports canAutoFix=true when an auto-fixable violation exists', async () => {
+      const action = makeAction('commit', {
+        commitMessage: 'feat(x): thing\n\nGenerated with Claude',
+        files: ['app/x.ts'],
+        testOutput: '90% coverage',
+      });
+      const report = await service.validateAction(action);
+      expect(report.canAutoFix).toBe(true);
+    });
+
+    it('dedupes suggestions', async () => {
+      const action = makeAction('commit', {
+        commitMessage: 'feat(x): thing',
+        files: ['app/x.ts'],
+      });
+      const report = await service.validateAction(action);
+      expect(new Set(report.suggestions).size).toBe(report.suggestions.length);
+    });
+
+    it('meets the <500ms full-validation performance target', async () => {
+      const action = makeAction('commit', {
+        commitMessage: 'feat(x): thing',
+        files: ['app/x.ts'],
+        testOutput: '90% coverage',
+      });
+      const report = await service.validateAction(action);
+      expect(report.totalDuration).toBeLessThan(500);
+    });
+  });
+
+  describe('strict mode', () => {
+    it('fails on warnings when strictMode is enabled', async () => {
+      const strict = new RuleEnforcementService();
+      await strict.initialize(baseConfig({ strictMode: true }));
+      const action = makeAction('commit', {
+        // Non-conventional format => warning only, no error.
+        commitMessage: 'Added stuff',
+        files: ['app/x.ts'],
+        testOutput: '90% coverage',
+      });
+      const report = await strict.validateAction(action);
+      expect(report.warningCount).toBeGreaterThan(0);
+      expect(report.passed).toBe(false);
+    });
+
+    it('passes warnings when strictMode is disabled', async () => {
+      const action = makeAction('commit', {
+        commitMessage: 'Added stuff',
+        files: ['app/x.ts'],
+        testOutput: '90% coverage',
+      });
+      const report = await service.validateAction(action);
+      // no errors, only warnings -> passes in non-strict mode
+      expect(report.errorCount).toBe(0);
+      expect(report.passed).toBe(true);
+    });
+  });
+
+  describe('autoFixViolations', () => {
+    it('works without prior initialize() (lazy-loads built-in rules)', async () => {
+      const fresh = new RuleEnforcementService();
+      const action = makeAction('commit', {
+        commitMessage: 'feat: x\n\nGenerated with Claude',
+      });
+      const fixed = await fresh.autoFixViolations(action, [
+        {
+          ruleId: RULE_IDS.NO_AI_ATTRIBUTION,
+          level: 'error',
+          message: 'attribution',
+          autoFixable: true,
+        },
+      ]);
+      expect(fixed.data.commitMessage).not.toContain('Claude');
+    });
+
+    it('does not mutate the input action', async () => {
+      const original = 'feat: x\n\nCo-Authored-By: Claude';
+      const action = makeAction('commit', { commitMessage: original });
+      await service.autoFixViolations(action, [
+        {
+          ruleId: RULE_IDS.NO_AI_ATTRIBUTION,
+          level: 'error',
+          message: 'attribution',
+          autoFixable: true,
+        },
+      ]);
+      expect(action.data.commitMessage).toBe(original);
+    });
+
+    it('fixes reconstructed violations that carry no closure', async () => {
+      const action = makeAction('file-edit', {
+        filePath: 'lib/x.ts',
+        fileContent: 'console.log("debug")',
+      });
+      // Violation shaped like one deserialized from an HTTP request body.
+      const fixed = await service.autoFixViolations(action, [
+        {
+          ruleId: RULE_IDS.NO_CONSOLE_LOG,
+          level: 'warning',
+          message: 'console.log',
+          autoFixable: true,
+        },
+      ]);
+      expect(fixed.data.fileContent).toContain('logger.info(');
+    });
+
+    it('ignores non-auto-fixable violations', async () => {
+      const action = makeAction('commit', { commitMessage: 'feat: x' });
+      const fixed = await service.autoFixViolations(action, [
+        {
+          ruleId: RULE_IDS.MANDATORY_TEST_EXECUTION,
+          level: 'error',
+          message: 'no tests',
+          autoFixable: false,
+        },
+      ]);
+      expect(fixed.data.commitMessage).toBe('feat: x');
+    });
+  });
+
+  describe('registerRule', () => {
+    it('registers and retrieves a custom rule', () => {
+      service.registerRule({
+        id: 'custom/no-todo',
+        name: 'No TODO',
+        description: 'Block TODO comments',
+        level: 'warning',
+        contexts: ['file-edit'],
+        enabled: true,
+        category: 'code-quality',
+        tags: ['custom'],
+        check: async (a) => ({
+          ruleId: 'custom/no-todo',
+          passed: !a.data.fileContent?.includes('TODO'),
+          violations: a.data.fileContent?.includes('TODO')
+            ? [
+                {
+                  ruleId: 'custom/no-todo',
+                  level: 'warning',
+                  message: 'TODO found',
+                  autoFixable: false,
+                },
+              ]
+            : [],
+          duration: 0,
+        }),
+      });
+      expect(service.getRule('custom/no-todo')).toBeDefined();
+    });
+
+    it('applies a registered custom rule during validation', async () => {
+      service.registerRule({
+        id: 'custom/no-todo',
+        name: 'No TODO',
+        description: 'Block TODO comments',
+        level: 'error',
+        contexts: ['file-edit'],
+        enabled: true,
+        category: 'code-quality',
+        tags: ['custom'],
+        check: async (a) => {
+          const bad = a.data.fileContent?.includes('TODO');
+          return {
+            ruleId: 'custom/no-todo',
+            passed: !bad,
+            violations: bad
+              ? [
+                  {
+                    ruleId: 'custom/no-todo',
+                    level: 'error',
+                    message: 'TODO found',
+                    autoFixable: false,
+                  },
+                ]
+              : [],
+            duration: 0,
+          };
+        },
+      });
+      const report = await service.validateAction(
+        makeAction('file-edit', {
+          filePath: 'lib/x.ts',
+          fileContent: '// TODO: fix later',
+        })
+      );
+      expect(report.passed).toBe(false);
+    });
+
+    it('skips disabled rules', async () => {
+      service.registerRule({
+        id: 'custom/disabled',
+        name: 'Disabled',
+        description: 'never runs',
+        level: 'error',
+        contexts: ['file-edit'],
+        enabled: false,
+        category: 'code-quality',
+        tags: [],
+        check: async () => ({
+          ruleId: 'custom/disabled',
+          passed: false,
+          violations: [
+            {
+              ruleId: 'custom/disabled',
+              level: 'error',
+              message: 'should not appear',
+              autoFixable: false,
+            },
+          ],
+          duration: 0,
+        }),
+      });
+      const report = await service.validateAction(
+        makeAction('file-edit', { filePath: 'lib/x.ts', fileContent: 'ok' })
+      );
+      const ids = report.results.map((r) => r.ruleId);
+      expect(ids).not.toContain('custom/disabled');
+    });
+  });
+
+  describe('error handling', () => {
+    it('captures a thrown error from a rule check as an error violation', async () => {
+      service.registerRule({
+        id: 'custom/throws',
+        name: 'Throws',
+        description: 'always throws',
+        level: 'error',
+        contexts: ['file-edit'],
+        enabled: true,
+        category: 'code-quality',
+        tags: [],
+        check: async () => {
+          throw new Error('boom');
+        },
+      });
+      const report = await service.validateAction(
+        makeAction('file-edit', { filePath: 'lib/x.ts', fileContent: 'ok' })
+      );
+      const violations = report.results.flatMap((r) => r.violations);
+      expect(
+        violations.some((v) => v.message.includes('boom'))
+      ).toBe(true);
+    });
+  });
+});

--- a/app/settings/rules/page.tsx
+++ b/app/settings/rules/page.tsx
@@ -1,0 +1,441 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { AppHeader } from '@/components/shared/app-header'
+import { EnforcementDashboard } from '@/components/enforcement/enforcement-dashboard'
+import { Loader2, ShieldCheck, PlayCircle } from 'lucide-react'
+import { useToast } from '@/components/ui/use-toast'
+import type {
+  EnforcementReport,
+  RuleContext,
+  RuleViolation,
+} from '@/lib/types/enforcement-rules'
+
+interface RuleRow {
+  id: string
+  name: string
+  description: string
+  level: string
+  category: string
+  contexts: string[]
+  enabled: boolean
+}
+
+const VALIDATION_CONTEXTS: { value: RuleContext; label: string }[] = [
+  { value: 'commit', label: 'Commit' },
+  { value: 'file-create', label: 'Create file' },
+  { value: 'file-edit', label: 'Edit file' },
+  { value: 'pr-create', label: 'Open PR' },
+  { value: 'branch-create', label: 'Create branch' },
+]
+
+const levelBadgeClass = (level: string) => {
+  switch (level) {
+    case 'error':
+      return 'bg-red-500/10 text-red-700 border-red-500/20 dark:text-red-400'
+    case 'warning':
+      return 'bg-yellow-500/10 text-yellow-700 border-yellow-500/20 dark:text-yellow-400'
+    default:
+      return 'bg-blue-500/10 text-blue-700 border-blue-500/20 dark:text-blue-400'
+  }
+}
+
+export default function RulesSettingsPage() {
+  const { toast } = useToast()
+  const [rules, setRules] = useState<RuleRow[]>([])
+  const [loading, setLoading] = useState(true)
+
+  // Validation playground state
+  const [context, setContext] = useState<RuleContext>('commit')
+  const [commitMessage, setCommitMessage] = useState(
+    'feat(auth): add login\n\nGenerated with Claude'
+  )
+  const [filePath, setFilePath] = useState('SUMMARY.md')
+  const [fileContent, setFileContent] = useState('')
+  const [report, setReport] = useState<EnforcementReport | null>(null)
+  const [validating, setValidating] = useState(false)
+
+  const fetchRules = useCallback(async () => {
+    try {
+      setLoading(true)
+      const res = await fetch('/api/rules')
+      if (!res.ok) throw new Error('Failed to load rules')
+      const data = await res.json()
+      setRules(data.rules || [])
+    } catch (error) {
+      toast({
+        title: 'Failed to load rules',
+        description: error instanceof Error ? error.message : 'Unknown error',
+        variant: 'destructive',
+      })
+    } finally {
+      setLoading(false)
+    }
+  }, [toast])
+
+  useEffect(() => {
+    fetchRules()
+  }, [fetchRules])
+
+  const toggleRule = async (rule: RuleRow) => {
+    // Optimistic update.
+    setRules((prev) =>
+      prev.map((r) =>
+        r.id === rule.id ? { ...r, enabled: !r.enabled } : r
+      )
+    )
+    try {
+      const res = await fetch(`/api/rules/${encodeURIComponent(rule.id)}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled: !rule.enabled }),
+      })
+      if (!res.ok) throw new Error('Update failed')
+    } catch (error) {
+      // Revert on failure.
+      setRules((prev) =>
+        prev.map((r) =>
+          r.id === rule.id ? { ...r, enabled: rule.enabled } : r
+        )
+      )
+      toast({
+        title: 'Could not update rule',
+        description: error instanceof Error ? error.message : 'Unknown error',
+        variant: 'destructive',
+      })
+    }
+  }
+
+  const buildActionData = () => {
+    switch (context) {
+      case 'commit':
+      case 'pr-create':
+        return {
+          commitMessage,
+          prTitle: commitMessage.split('\n')[0],
+          prDescription: commitMessage,
+          files: fileContent ? [filePath] : undefined,
+        }
+      case 'file-create':
+      case 'file-edit':
+        return { filePath, fileContent }
+      case 'branch-create':
+        return { branch: filePath }
+      default:
+        return {}
+    }
+  }
+
+  const runValidation = async () => {
+    setValidating(true)
+    setReport(null)
+    try {
+      const res = await fetch('/api/rules/validate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          type: context,
+          data: buildActionData(),
+          userId: 'playground',
+          projectId: 'playground',
+        }),
+      })
+      const data = await res.json()
+      if (!data.success) throw new Error(data.error || 'Validation failed')
+
+      // Rebuild an EnforcementReport shape from the API summary for the dashboard.
+      const violations: RuleViolation[] = data.report.violations || []
+      const grouped = new Map<string, RuleViolation[]>()
+      for (const v of violations) {
+        grouped.set(v.ruleId, [...(grouped.get(v.ruleId) || []), v])
+      }
+      setReport({
+        action: {
+          type: context,
+          data: buildActionData(),
+          userId: 'playground',
+          projectId: 'playground',
+          timestamp: new Date(),
+        },
+        results: Array.from(grouped.entries()).map(([ruleId, vs]) => ({
+          ruleId,
+          passed: false,
+          violations: vs,
+          duration: 0,
+        })),
+        passed: data.report.passed,
+        errorCount: data.report.errorCount,
+        warningCount: data.report.warningCount,
+        infoCount: data.report.infoCount,
+        totalDuration: data.report.totalDuration,
+        timestamp: new Date(),
+        canAutoFix: data.report.canAutoFix,
+        suggestions: data.report.suggestions || [],
+      })
+    } catch (error) {
+      toast({
+        title: 'Validation failed',
+        description: error instanceof Error ? error.message : 'Unknown error',
+        variant: 'destructive',
+      })
+    } finally {
+      setValidating(false)
+    }
+  }
+
+  const applyFixes = async () => {
+    if (!report) return
+    const violations = report.results.flatMap((r) => r.violations)
+    try {
+      const res = await fetch('/api/rules/auto-fix', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          action: {
+            type: context,
+            data: buildActionData(),
+            userId: 'playground',
+            projectId: 'playground',
+          },
+          violations,
+        }),
+      })
+      const data = await res.json()
+      if (!data.success) throw new Error(data.error || 'Auto-fix failed')
+
+      // Reflect fixes back into the editor and re-validate.
+      const fixed = data.action?.data || {}
+      if (typeof fixed.commitMessage === 'string')
+        setCommitMessage(fixed.commitMessage)
+      if (typeof fixed.fileContent === 'string')
+        setFileContent(fixed.fileContent)
+
+      toast({
+        title: 'Auto-fix applied',
+        description: `Fixed ${data.fixedCount} violation(s)`,
+      })
+      await runValidation()
+    } catch (error) {
+      toast({
+        title: 'Auto-fix failed',
+        description: error instanceof Error ? error.message : 'Unknown error',
+        variant: 'destructive',
+      })
+    }
+  }
+
+  const usesContent =
+    context === 'file-create' || context === 'file-edit'
+  const usesMessage = context === 'commit' || context === 'pr-create'
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-black">
+      <AppHeader />
+      <div className="container mx-auto max-w-5xl px-4 py-8">
+        <div className="mb-6">
+          <h1 className="mb-2 flex items-center gap-2 text-3xl font-bold text-gray-900 dark:text-white">
+            <ShieldCheck className="h-7 w-7 text-emerald-600" />
+            Rule Enforcement
+          </h1>
+          <p className="text-gray-600 dark:text-gray-400">
+            Pre-flight checks that block standards violations before they ship.
+            Toggle rules and test actions against them below.
+          </p>
+        </div>
+
+        {/* Validation playground */}
+        <Card className="mb-8">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <PlayCircle className="h-5 w-5" /> Validation Playground
+            </CardTitle>
+            <CardDescription>
+              Run an action through the enforcement engine and preview
+              violations with one-click auto-fix.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-2">
+                <Label>Action type</Label>
+                <Select
+                  value={context}
+                  onValueChange={(v) => setContext(v as RuleContext)}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {VALIDATION_CONTEXTS.map((c) => (
+                      <SelectItem key={c.value} value={c.value}>
+                        {c.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              {(usesContent || context === 'branch-create') && (
+                <div className="space-y-2">
+                  <Label>
+                    {context === 'branch-create' ? 'Branch name' : 'File path'}
+                  </Label>
+                  <input
+                    className="w-full rounded-md border bg-transparent px-3 py-2 text-sm"
+                    value={filePath}
+                    onChange={(e) => setFilePath(e.target.value)}
+                  />
+                </div>
+              )}
+            </div>
+
+            {usesMessage && (
+              <div className="space-y-2">
+                <Label>Commit / PR message</Label>
+                <Textarea
+                  rows={4}
+                  value={commitMessage}
+                  onChange={(e) => setCommitMessage(e.target.value)}
+                />
+              </div>
+            )}
+
+            {usesContent && (
+              <div className="space-y-2">
+                <Label>File content</Label>
+                <Textarea
+                  rows={4}
+                  value={fileContent}
+                  onChange={(e) => setFileContent(e.target.value)}
+                  placeholder='const API_KEY = "sk_live_..."'
+                />
+              </div>
+            )}
+
+            <Button onClick={runValidation} disabled={validating}>
+              {validating ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Validating...
+                </>
+              ) : (
+                <>
+                  <PlayCircle className="mr-2 h-4 w-4" />
+                  Validate action
+                </>
+              )}
+            </Button>
+          </CardContent>
+        </Card>
+
+        {report && (
+          <div className="mb-8">
+            <EnforcementDashboard
+              report={report}
+              onApplyFixes={report.canAutoFix ? applyFixes : undefined}
+            />
+          </div>
+        )}
+
+        {/* Rules table */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Enforcement Rules</CardTitle>
+            <CardDescription>
+              {loading
+                ? 'Loading rules...'
+                : `${rules.length} rule${rules.length !== 1 ? 's' : ''} configured`}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {loading ? (
+              <div className="flex h-40 items-center justify-center">
+                <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
+              </div>
+            ) : rules.length === 0 ? (
+              <div className="py-12 text-center text-gray-500 dark:text-gray-400">
+                No rules found. Built-in rules are seeded on first run.
+              </div>
+            ) : (
+              <div className="rounded-lg border">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Rule</TableHead>
+                      <TableHead>Category</TableHead>
+                      <TableHead>Level</TableHead>
+                      <TableHead>Contexts</TableHead>
+                      <TableHead className="text-right">Enabled</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {rules.map((rule) => (
+                      <TableRow key={rule.id}>
+                        <TableCell>
+                          <div className="font-medium">{rule.name}</div>
+                          <code className="text-xs text-muted-foreground">
+                            {rule.id}
+                          </code>
+                        </TableCell>
+                        <TableCell>
+                          <Badge variant="secondary">{rule.category}</Badge>
+                        </TableCell>
+                        <TableCell>
+                          <Badge
+                            variant="outline"
+                            className={levelBadgeClass(rule.level)}
+                          >
+                            {rule.level}
+                          </Badge>
+                        </TableCell>
+                        <TableCell>
+                          <span className="text-xs text-muted-foreground">
+                            {(rule.contexts || []).join(', ')}
+                          </span>
+                        </TableCell>
+                        <TableCell className="text-right">
+                          <Button
+                            variant={rule.enabled ? 'default' : 'outline'}
+                            size="sm"
+                            onClick={() => toggleRule(rule)}
+                          >
+                            {rule.enabled ? 'On' : 'Off'}
+                          </Button>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/lib/services/built-in-rules.ts
+++ b/lib/services/built-in-rules.ts
@@ -96,6 +96,48 @@ export const NO_AI_ATTRIBUTION_RULE: EnforcementRule = {
       duration: Date.now() - startTime,
     };
   },
+  autoFix: async (action: AgentAction): Promise<AgentAction> => {
+    // Ordered so multi-word terms (e.g. "Co-Authored-By: Claude",
+    // "Generated with Claude") are stripped before their single-word parts.
+    const replacements: { term: string; replacement: string }[] = [
+      { term: 'Co-Authored-By: Claude', replacement: '' },
+      { term: 'Co-Authored-By: ChatGPT', replacement: '' },
+      { term: 'Co-Authored-By: Copilot', replacement: '' },
+      { term: 'Generated with Claude', replacement: 'Built by AINative' },
+      { term: 'Generated with ChatGPT', replacement: 'Built by AINative' },
+      { term: 'Powered by Claude', replacement: 'Powered by AINative Cloud' },
+      { term: 'GitHub Copilot', replacement: 'AINative' },
+      { term: 'claude.com', replacement: 'ainative.com' },
+      { term: 'Claude', replacement: 'AINative' },
+      { term: 'Anthropic', replacement: 'AINative' },
+      { term: 'ChatGPT', replacement: 'AINative' },
+      { term: 'OpenAI', replacement: 'AINative' },
+      { term: 'Copilot', replacement: 'AINative' },
+    ];
+
+    const escapeRegExp = (s: string) =>
+      s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+    const strip = (input?: string): string | undefined => {
+      if (!input) return input;
+      let out = input;
+      for (const { term, replacement } of replacements) {
+        out = out.replace(new RegExp(escapeRegExp(term), 'gi'), replacement);
+      }
+      // Collapse any blank lines left behind by removed trailer lines.
+      return out.replace(/[ \t]+$/gm, '').replace(/\n{3,}/g, '\n\n');
+    };
+
+    return {
+      ...action,
+      data: {
+        ...action.data,
+        commitMessage: strip(action.data.commitMessage),
+        prDescription: strip(action.data.prDescription),
+        prTitle: strip(action.data.prTitle),
+      },
+    };
+  },
   examples: [
     {
       invalid: 'Add user authentication\n\nGenerated with Claude Code',
@@ -864,6 +906,18 @@ logger.info({ userId }, 'User logged in');`,
       passed: violations.length === 0,
       violations,
       duration: Date.now() - startTime,
+    };
+  },
+  autoFix: async (action: AgentAction): Promise<AgentAction> => {
+    return {
+      ...action,
+      data: {
+        ...action.data,
+        fileContent: action.data.fileContent?.replace(
+          /console\.log\(/g,
+          'logger.info('
+        ),
+      },
     };
   },
   examples: [

--- a/lib/services/rule-enforcement.service.ts
+++ b/lib/services/rule-enforcement.service.ts
@@ -60,18 +60,51 @@ export class RuleEnforcementService {
   }
 
   /**
-   * Auto-fix all fixable violations
+   * Auto-fix all fixable violations.
+   *
+   * Returns a NEW action with fixes applied. The input action is never mutated.
+   *
+   * Fixes are applied deterministically by looking up the registered rule for
+   * each violation and invoking its rule-level `autoFix(action)`. This works
+   * for reconstructed violations coming over HTTP (which have no live closures),
+   * unlike relying on the per-violation `autoFix()` closure.
    */
   async autoFixViolations(
     action: AgentAction,
     violations: RuleViolation[]
   ): Promise<AgentAction> {
-    let fixedAction = { ...action };
+    // Ensure built-in rules are available even if initialize() was skipped.
+    if (this.rules.size === 0) {
+      await this.loadBuiltInRules();
+    }
 
+    // Deep-copy so callers' input is never mutated.
+    let fixedAction: AgentAction = {
+      ...action,
+      data: { ...action.data },
+    };
+
+    // De-duplicate by ruleId — one autoFix pass per rule is sufficient.
+    const ruleIds = new Set<string>();
     for (const violation of violations) {
-      if (violation.autoFixable && violation.autoFix) {
-        await violation.autoFix();
-        // TODO: Track that this violation was auto-fixed
+      if (violation.autoFixable) {
+        ruleIds.add(violation.ruleId);
+      }
+    }
+
+    for (const ruleId of ruleIds) {
+      const rule = this.rules.get(ruleId);
+      if (rule?.autoFix) {
+        fixedAction = await rule.autoFix(fixedAction);
+      } else {
+        // Fall back to a live per-violation closure if a rule-level fixer
+        // is unavailable (e.g. custom in-memory violations).
+        const violation = violations.find(
+          (v) => v.ruleId === ruleId && v.autoFix
+        );
+        if (violation?.autoFix) {
+          await violation.autoFix();
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

Completes the **Rule Enforcement Framework** (issue #18). The repo already had the types, service skeleton, 13 built-in rules, the DB service, and the full `/api/rules/*` route surface. This PR closes the remaining gaps from the acceptance criteria: a **working, deterministic auto-fix**, a **real UI** wiring the enforcement components into the app, and the **unit test suite** the issue's Test Plan requires.

### What changed
- **Deterministic, pure auto-fix** (`lib/services/rule-enforcement.service.ts`)
  - `autoFixViolations` now deep-copies the action (never mutates input), de-dupes by `ruleId`, and applies each fix via the registered rule's rule-level `autoFix(action)`.
  - This makes `POST /api/rules/auto-fix` actually fix **reconstructed (HTTP-deserialized) violations** that carry no live closure — previously a no-op.
  - Lazy-loads built-in rules when called without a prior `initialize()`.
- **Rule-level `autoFix(action)`** added to the two auto-fixable built-in rules (`no-ai-attribution`, `no-console-log`) with ordered, regex-escaped term replacement and blank-line collapsing (`lib/services/built-in-rules.ts`).
- **Rule Enforcement settings page** (`app/settings/rules/page.tsx`)
  - **Validation Playground**: run a commit / file / PR / branch action through the engine, see violations via the existing `EnforcementDashboard`, and one-click **Auto-Fix** (round-trips through `/api/rules/validate` + `/api/rules/auto-fix`).
  - **Rule configuration table**: enable/disable rules via `PUT /api/rules/[ruleId]`.
- **Unit tests** (67):
  - `__tests__/lib/built-in-rules.test.ts` — every one of the 13 rules, pass + fail paths, plus auto-fix + non-mutation.
  - `__tests__/services/rule-enforcement.service.test.ts` — the issue's exact Test Plan cases (blocks AI attribution, auto-fixes attribution, prevents root `.md`, detects secrets) plus report aggregation, strict mode, custom-rule registration, disabled-rule skipping, and rule-check error handling.

### Acceptance criteria addressed
- [x] 10+ built-in rules (git, files, testing, security) — 13 rules, verified by tests
- [x] Pre-flight validation before commits (validate route + playground)
- [x] Auto-fix for common violations (now deterministic + works over HTTP)
- [x] Violation UI with auto-fix (`/settings/rules`)
- [x] Rule configuration UI (enable/disable)
- [x] Unit tests from the Test Plan

### Test evidence
```
pnpm exec vitest run __tests__/lib/built-in-rules.test.ts __tests__/services/rule-enforcement.service.test.ts
 ✓ __tests__/lib/built-in-rules.test.ts (47 tests)
 ✓ __tests__/services/rule-enforcement.service.test.ts (20 tests)
 Test Files  2 passed (2)
      Tests  67 passed (67)
```
Full suite (`pnpm test`): **525 passed / 30 skipped**. The 10 remaining failures are **pre-existing and unrelated** (`evidence.test.ts` `@/lib/db` module resolution, `agent-skill.service.test.ts` timing, `subagents.test.ts`) — confirmed failing identically on the base commit with these changes stashed.

### Build evidence
```
pnpm build
 ✓ Compiled successfully in 22.6s
 ○ /settings/rules   5.96 kB   217 kB   (prerendered)
```

### Notes
- Secret test fixtures are constructed at runtime (`['sk','live', 'x'.repeat(28)].join('_')`) so no scannable literal ships in source (push-protection safe) while still matching the rule regex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)