### PR TITLE
feat(context-budget): harden Context Budget Manager — testable pure logic + history-query fix (#20)

### DIFF
--- a/__tests__/services/context-budget-logic.test.ts
+++ b/__tests__/services/context-budget-logic.test.ts
@@ -1,0 +1,322 @@
+/**
+ * Context Budget Manager - Pure Logic Tests
+ *
+ * Exercises the deterministic, DB-agnostic budgeting logic that powers the
+ * Context Budget Manager (Issue #20). These map directly to the issue's Test
+ * Plan: pre-load cost/availability, canLoad gating, optimization suggestions,
+ * per-category breakdown, priority scoring, and unload-candidate selection.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  calculateBudgetState,
+  canLoad,
+  calculatePriorityScore,
+  calculateAllocations,
+  mapTypeToCategory,
+  findUnloadCandidates,
+  generateOptimizationSuggestions,
+  PRIORITY_SCORES,
+  WARNING_THRESHOLD_PCT,
+  CRITICAL_THRESHOLD_PCT,
+  type BudgetItemInput,
+} from '@/lib/services/context-budget-logic';
+
+const NOW = 1_700_000_000_000; // fixed reference "now" for determinism
+
+function item(overrides: Partial<BudgetItemInput>): BudgetItemInput {
+  return {
+    type: 'file',
+    name: 'item',
+    tokenCost: 1000,
+    priority: 'medium',
+    status: 'loaded',
+    accessCount: 5,
+    lastAccessedAt: new Date(NOW),
+    ...overrides,
+  };
+}
+
+describe('calculateBudgetState', () => {
+  it('computes remaining and usage percentage', () => {
+    const state = calculateBudgetState(128000, 5000);
+    expect(state.remaining).toBe(123000);
+    expect(state.usagePercentage).toBe(4);
+    expect(state.isWarning).toBe(false);
+    expect(state.isCritical).toBe(false);
+  });
+
+  it('flags warning at the 80% threshold', () => {
+    const state = calculateBudgetState(100, WARNING_THRESHOLD_PCT);
+    expect(state.isWarning).toBe(true);
+    expect(state.isCritical).toBe(false);
+  });
+
+  it('flags critical at the 95% threshold', () => {
+    const state = calculateBudgetState(100, CRITICAL_THRESHOLD_PCT);
+    expect(state.isWarning).toBe(true);
+    expect(state.isCritical).toBe(true);
+  });
+
+  it('clamps used tokens into [0, total] (never negative remaining)', () => {
+    const over = calculateBudgetState(1000, 5000);
+    expect(over.used).toBe(1000);
+    expect(over.remaining).toBe(0);
+    expect(over.usagePercentage).toBe(100);
+
+    const under = calculateBudgetState(1000, -50);
+    expect(under.used).toBe(0);
+    expect(under.remaining).toBe(1000);
+  });
+
+  it('handles a zero total budget without dividing by zero', () => {
+    const state = calculateBudgetState(0, 0);
+    expect(state.usagePercentage).toBe(0);
+    expect(state.remaining).toBe(0);
+  });
+});
+
+describe('canLoad', () => {
+  it('allows loading when cost fits remaining budget', () => {
+    const { remaining } = calculateBudgetState(200000, 45000);
+    expect(canLoad(2000, remaining)).toBe(true);
+  });
+
+  it('prevents loading when budget is insufficient', () => {
+    // Test Plan: total 10000, used 9500 => remaining 500 < cost 2000
+    const { remaining } = calculateBudgetState(10000, 9500);
+    expect(canLoad(2000, remaining)).toBe(false);
+    expect(remaining).toBeLessThan(2000);
+  });
+
+  it('treats an exact-fit item as loadable', () => {
+    expect(canLoad(500, 500)).toBe(true);
+  });
+});
+
+describe('mapTypeToCategory', () => {
+  it('maps known types to their categories', () => {
+    expect(mapTypeToCategory('skill')).toBe('skills');
+    expect(mapTypeToCategory('file')).toBe('files');
+    expect(mapTypeToCategory('message')).toBe('history');
+    expect(mapTypeToCategory('history')).toBe('history');
+    expect(mapTypeToCategory('tool')).toBe('tools');
+    expect(mapTypeToCategory('baseline')).toBe('baseline');
+  });
+
+  it('falls back to "other" for unknown types', () => {
+    expect(mapTypeToCategory('mystery')).toBe('other');
+  });
+});
+
+describe('calculateAllocations', () => {
+  it('tracks usage by category (Test Plan: breakdown.skills)', () => {
+    const allocations = calculateAllocations(
+      [item({ type: 'skill', tokenCost: 2000 })],
+      128000
+    );
+    const skills = allocations.find((a) => a.category === 'skills')!;
+    expect(skills.tokens).toBe(2000);
+    expect(skills.itemCount).toBe(1);
+  });
+
+  it('always returns all six categories, zeroed when empty', () => {
+    const allocations = calculateAllocations([], 128000);
+    expect(allocations.map((a) => a.category).sort()).toEqual(
+      ['baseline', 'files', 'history', 'other', 'skills', 'tools'].sort()
+    );
+    expect(allocations.every((a) => a.tokens === 0 && a.itemCount === 0)).toBe(true);
+  });
+
+  it('aggregates multiple items and computes percentage', () => {
+    const allocations = calculateAllocations(
+      [
+        item({ type: 'file', tokenCost: 6000 }),
+        item({ type: 'file', tokenCost: 4000 }),
+      ],
+      100000
+    );
+    const files = allocations.find((a) => a.category === 'files')!;
+    expect(files.tokens).toBe(10000);
+    expect(files.itemCount).toBe(2);
+    expect(files.percentage).toBe(10);
+  });
+
+  it('flags a category as over budget when it exceeds its max percentage', () => {
+    // baseline max is 20%; 30000 / 100000 = 30% > 20%
+    const allocations = calculateAllocations(
+      [item({ type: 'baseline', tokenCost: 30000 })],
+      100000
+    );
+    const baseline = allocations.find((a) => a.category === 'baseline')!;
+    expect(baseline.isOverBudget).toBe(true);
+  });
+});
+
+describe('calculatePriorityScore', () => {
+  it('uses base priority scores', () => {
+    const base = { isWarning: false, isCritical: false };
+    expect(
+      calculatePriorityScore({ type: 'message', priority: 'critical', tokenCost: 100 }, base)
+    ).toBe(PRIORITY_SCORES.critical + 3); // message bonus = 3
+  });
+
+  it('penalizes loading under budget pressure', () => {
+    const normal = calculatePriorityScore(
+      { type: 'skill', priority: 'high', tokenCost: 100 },
+      { isWarning: false, isCritical: false }
+    );
+    const warning = calculatePriorityScore(
+      { type: 'skill', priority: 'high', tokenCost: 100 },
+      { isWarning: true, isCritical: false }
+    );
+    const critical = calculatePriorityScore(
+      { type: 'skill', priority: 'high', tokenCost: 100 },
+      { isWarning: false, isCritical: true }
+    );
+    expect(warning).toBeLessThan(normal);
+    expect(critical).toBeLessThan(warning);
+  });
+
+  it('penalizes very expensive items', () => {
+    const base = { isWarning: false, isCritical: false };
+    const cheap = calculatePriorityScore(
+      { type: 'file', priority: 'high', tokenCost: 100 },
+      base
+    );
+    const expensive = calculatePriorityScore(
+      { type: 'file', priority: 'high', tokenCost: 6000 },
+      base
+    );
+    expect(expensive).toBe(cheap - 10);
+  });
+});
+
+describe('findUnloadCandidates', () => {
+  const options = {
+    eligiblePriorities: ['low', 'medium'] as const,
+    minAccessCount: 1,
+    minTimeSinceAccess: 300000, // 5 min
+    now: NOW,
+  };
+
+  it('never selects critical items', () => {
+    const items = [
+      item({ id: 'a', priority: 'critical', tokenCost: 5000, lastAccessedAt: new Date(NOW - 999999) }),
+    ];
+    expect(findUnloadCandidates(items, 1000, options)).toHaveLength(0);
+  });
+
+  it('selects lowest-priority, stalest items first until enough is freed', () => {
+    const items = [
+      item({ id: 'high', priority: 'high', tokenCost: 3000, lastAccessedAt: new Date(NOW - 999999) }),
+      item({ id: 'low-old', priority: 'low', tokenCost: 800, lastAccessedAt: new Date(NOW - 900000) }),
+      item({ id: 'low-older', priority: 'low', tokenCost: 800, lastAccessedAt: new Date(NOW - 999999) }),
+      item({ id: 'medium', priority: 'medium', tokenCost: 800, lastAccessedAt: new Date(NOW - 900000) }),
+    ];
+    const chosen = findUnloadCandidates(items, 1000, { ...options, eligiblePriorities: ['low', 'medium'] });
+    // low priority comes first; oldest low first; needs >=1000 so two low items.
+    expect(chosen.map((c) => c.id)).toEqual(['low-older', 'low-old']);
+  });
+
+  it('skips items accessed too recently (min time since access)', () => {
+    const items = [
+      item({ id: 'recent', priority: 'low', tokenCost: 2000, lastAccessedAt: new Date(NOW - 1000) }),
+    ];
+    expect(findUnloadCandidates(items, 1000, options)).toHaveLength(0);
+  });
+
+  it('returns fewer than needed when not enough eligible items exist', () => {
+    const items = [
+      item({ id: 'only', priority: 'low', tokenCost: 500, lastAccessedAt: new Date(NOW - 999999) }),
+    ];
+    const chosen = findUnloadCandidates(items, 5000, options);
+    expect(chosen.map((c) => c.id)).toEqual(['only']);
+  });
+});
+
+describe('generateOptimizationSuggestions', () => {
+  it('suggests unloading rarely accessed items when near limit (Test Plan)', () => {
+    const items = [
+      item({ id: '1', type: 'skill', priority: 'low', tokenCost: 4000, accessCount: 0 }),
+      item({ id: '2', type: 'skill', priority: 'medium', tokenCost: 2000, accessCount: 0 }),
+    ];
+    const suggestions = generateOptimizationSuggestions(items, { now: NOW });
+    const unload = suggestions.find((s) => s.type === 'unload');
+    expect(unload).toBeDefined();
+    expect(unload!.estimatedSavings).toBe(6000);
+    expect(unload!.affectedItems).toHaveLength(2);
+  });
+
+  it('never suggests unloading critical items', () => {
+    const items = [item({ type: 'skill', priority: 'critical', accessCount: 0 })];
+    const suggestions = generateOptimizationSuggestions(items, { now: NOW });
+    expect(suggestions.find((s) => s.type === 'unload')).toBeUndefined();
+  });
+
+  it('suggests compressing large uncompressed files', () => {
+    const items = [
+      item({ type: 'file', tokenCost: 3000, accessCount: 5, metadata: {} }),
+    ];
+    const suggestions = generateOptimizationSuggestions(items, {
+      now: NOW,
+      compressionThreshold: 2000,
+    });
+    const compress = suggestions.find((s) => s.type === 'compress');
+    expect(compress).toBeDefined();
+    expect(compress!.estimatedSavings).toBe(1800); // 3000 * 0.6
+  });
+
+  it('does not suggest compressing already-compressed files', () => {
+    const items = [
+      item({ type: 'file', tokenCost: 3000, accessCount: 5, metadata: { compressed: true } }),
+    ];
+    const suggestions = generateOptimizationSuggestions(items, { now: NOW });
+    expect(suggestions.find((s) => s.type === 'compress')).toBeUndefined();
+  });
+
+  it('suggests summarizing more than two old messages', () => {
+    const old = new Date(NOW - 700000); // >10 min
+    const items = [
+      item({ type: 'message', tokenCost: 500, accessCount: 5, lastAccessedAt: old }),
+      item({ type: 'message', tokenCost: 500, accessCount: 5, lastAccessedAt: old }),
+      item({ type: 'message', tokenCost: 500, accessCount: 5, lastAccessedAt: old }),
+    ];
+    const suggestions = generateOptimizationSuggestions(items, { now: NOW });
+    const summarize = suggestions.find((s) => s.type === 'summarize');
+    expect(summarize).toBeDefined();
+    expect(summarize!.estimatedSavings).toBe(Math.round(1500 * 0.7));
+  });
+
+  it('ranks suggestions high -> medium -> low', () => {
+    const old = new Date(NOW - 700000);
+    const items = [
+      // low-access unload (high)
+      item({ id: 'u', type: 'file', priority: 'low', tokenCost: 100, accessCount: 0, metadata: {} }),
+      // old messages summarize (medium)
+      item({ id: 'm1', type: 'message', tokenCost: 100, accessCount: 5, lastAccessedAt: old }),
+      item({ id: 'm2', type: 'message', tokenCost: 100, accessCount: 5, lastAccessedAt: old }),
+      item({ id: 'm3', type: 'message', tokenCost: 100, accessCount: 5, lastAccessedAt: old }),
+      // 4 skills in same category consolidate (low)
+      item({ id: 's1', type: 'skill', tokenCost: 100, accessCount: 5, metadata: { summary: 'git' } }),
+      item({ id: 's2', type: 'skill', tokenCost: 100, accessCount: 5, metadata: { summary: 'git' } }),
+      item({ id: 's3', type: 'skill', tokenCost: 100, accessCount: 5, metadata: { summary: 'git' } }),
+      item({ id: 's4', type: 'skill', tokenCost: 100, accessCount: 5, metadata: { summary: 'git' } }),
+    ];
+    const suggestions = generateOptimizationSuggestions(items, { now: NOW });
+    const priorities = suggestions.map((s) => s.priority);
+    const order = { high: 0, medium: 1, low: 2 } as const;
+    for (let i = 1; i < priorities.length; i++) {
+      expect(order[priorities[i]]).toBeGreaterThanOrEqual(order[priorities[i - 1]]);
+    }
+    expect(suggestions.some((s) => s.type === 'consolidate')).toBe(true);
+  });
+
+  it('returns no suggestions for a lean, well-used context', () => {
+    const items = [
+      item({ type: 'skill', tokenCost: 500, accessCount: 10, priority: 'high' }),
+    ];
+    const suggestions = generateOptimizationSuggestions(items, { now: NOW });
+    expect(suggestions).toHaveLength(0);
+  });
+});

--- a/app/api/context/budget/route.ts
+++ b/app/api/context/budget/route.ts
@@ -8,7 +8,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { contextBudgetService } from '@/lib/services/context-budget.service';
 import { logger } from '@/lib/logger';
 import { db } from '@/lib/db';
-import { context_items } from '@/lib/db/schema';
+import { context_items, budget_events } from '@/lib/db/schema';
 import { and, eq } from 'drizzle-orm';
 
 export async function GET(request: NextRequest) {
@@ -74,7 +74,7 @@ export async function GET(request: NextRequest) {
     // Include history if requested
     if (includeHistory) {
       const events = await db.query.budget_events.findMany({
-        where: eq(context_items.session_id, sessionId),
+        where: eq(budget_events.session_id, sessionId),
         orderBy: (events: any, { desc }: any) => [desc(events.created_at)],
         limit: 50,
       });

--- a/lib/services/context-budget-logic.ts
+++ b/lib/services/context-budget-logic.ts
@@ -1,0 +1,409 @@
+/**
+ * Context Budget Manager - Pure Logic
+ *
+ * Framework/DB-agnostic pure functions that power the Context Budget Manager
+ * (GitHub Issue #20). These are extracted from `context-budget.service.ts` so
+ * that the core budgeting math is:
+ *   - deterministic and side-effect free
+ *   - fully unit-testable without a database
+ *   - reusable by both the server service and any future client-side estimator
+ *
+ * The DB-bound service (`context-budget.service.ts`) delegates to these helpers
+ * for all budget calculations, priority scoring, allocation breakdown, unload
+ * candidate selection, and optimization suggestion generation.
+ */
+
+import type {
+  BudgetAllocation,
+  BudgetCategory,
+  ContextItem,
+  ContextItemPriority,
+  ContextItemType,
+  OptimizationSuggestion,
+} from '@/lib/types/context-budget';
+
+/**
+ * A minimal, DB-agnostic shape for a context item. Both the Drizzle row
+ * (snake_case) and the API `ContextItem` (camelCase) can be normalized to this
+ * before being passed to the pure helpers.
+ */
+export interface BudgetItemInput {
+  id?: string;
+  type: ContextItemType | string;
+  name?: string;
+  /** Token cost (camelCase preferred; snake_case tolerated by normalizer). */
+  tokenCost: number;
+  priority: ContextItemPriority | string;
+  status?: string;
+  accessCount?: number;
+  lastAccessedAt?: Date | null;
+  metadata?: ContextItem['metadata'];
+}
+
+/** Warning threshold (percentage of total budget used). */
+export const WARNING_THRESHOLD_PCT = 80;
+/** Critical threshold (percentage of total budget used). */
+export const CRITICAL_THRESHOLD_PCT = 95;
+
+/**
+ * Priority scores for loading decisions and unload ordering.
+ * Higher = more important to keep loaded.
+ */
+export const PRIORITY_SCORES: Record<ContextItemPriority, number> = {
+  critical: 100,
+  high: 75,
+  medium: 50,
+  low: 25,
+};
+
+/**
+ * Per-type bonus applied when scoring a load decision. Baseline/skill/tool
+ * context is generally more valuable to keep than raw message/history text.
+ */
+export const TYPE_LOAD_BONUS: Record<ContextItemType, number> = {
+  baseline: 20,
+  skill: 15,
+  tool: 10,
+  file: 5,
+  message: 3,
+  history: 1,
+};
+
+/** Default per-category allocation preferences (max % of total budget). */
+export const DEFAULT_CATEGORY_MAX_PCT: Record<BudgetCategory, number> = {
+  baseline: 20,
+  skills: 30,
+  files: 25,
+  tools: 15,
+  history: 20,
+  other: 10,
+};
+
+/**
+ * Map an item type to its budget category.
+ */
+export function mapTypeToCategory(type: string): BudgetCategory {
+  const mapping: Record<string, BudgetCategory> = {
+    skill: 'skills',
+    file: 'files',
+    message: 'history',
+    history: 'history',
+    tool: 'tools',
+    baseline: 'baseline',
+  };
+  return mapping[type] || 'other';
+}
+
+/** Clamp a number into the inclusive [min, max] range. */
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+/**
+ * Derived budget state (used/remaining/percentage/thresholds) for a given
+ * total capacity and consumed token count.
+ */
+export interface BudgetState {
+  total: number;
+  used: number;
+  remaining: number;
+  usagePercentage: number;
+  isWarning: boolean;
+  isCritical: boolean;
+}
+
+/**
+ * Compute the derived budget state from a total capacity and used tokens.
+ *
+ * `used` is clamped to [0, total] so callers never observe negative remaining
+ * or >100% usage even if upstream accounting drifts.
+ */
+export function calculateBudgetState(total: number, used: number): BudgetState {
+  const safeTotal = Math.max(0, total);
+  const safeUsed = clamp(used, 0, safeTotal);
+  const remaining = safeTotal - safeUsed;
+  const usagePercentage = safeTotal > 0 ? Math.round((safeUsed / safeTotal) * 100) : 0;
+
+  return {
+    total: safeTotal,
+    used: safeUsed,
+    remaining,
+    usagePercentage,
+    isWarning: usagePercentage >= WARNING_THRESHOLD_PCT,
+    isCritical: usagePercentage >= CRITICAL_THRESHOLD_PCT,
+  };
+}
+
+/**
+ * Can an item of `tokenCost` be loaded given `remaining` budget?
+ */
+export function canLoad(tokenCost: number, remaining: number): boolean {
+  return tokenCost <= remaining;
+}
+
+/**
+ * Score a candidate item for a smart-loading decision. Higher scores are more
+ * worth loading. The score blends base priority, budget pressure, type value,
+ * and a penalty for very expensive items.
+ */
+export function calculatePriorityScore(
+  item: Pick<BudgetItemInput, 'type' | 'priority' | 'tokenCost'>,
+  budget: Pick<BudgetState, 'isWarning' | 'isCritical'>
+): number {
+  let score = PRIORITY_SCORES[item.priority as ContextItemPriority] ?? 0;
+
+  // Penalize loading while under budget pressure.
+  if (budget.isCritical) {
+    score *= 0.5;
+  } else if (budget.isWarning) {
+    score *= 0.75;
+  }
+
+  score += TYPE_LOAD_BONUS[item.type as ContextItemType] ?? 0;
+
+  // Penalize very expensive items.
+  if (item.tokenCost > 5000) {
+    score -= 10;
+  }
+
+  return score;
+}
+
+/**
+ * Aggregate loaded items into per-category budget allocations.
+ * All six categories are always represented (zeroed when empty) so UIs can
+ * render a stable breakdown.
+ */
+export function calculateAllocations(
+  items: BudgetItemInput[],
+  totalBudget: number
+): BudgetAllocation[] {
+  const allCategories: BudgetCategory[] = [
+    'baseline',
+    'skills',
+    'files',
+    'history',
+    'tools',
+    'other',
+  ];
+
+  const totals = new Map<BudgetCategory, { tokens: number; count: number }>();
+  allCategories.forEach((cat) => totals.set(cat, { tokens: 0, count: 0 }));
+
+  for (const item of items) {
+    const category = mapTypeToCategory(String(item.type));
+    const bucket = totals.get(category)!;
+    bucket.tokens += item.tokenCost || 0;
+    bucket.count += 1;
+  }
+
+  return allCategories.map((category) => {
+    const data = totals.get(category)!;
+    const percentage =
+      totalBudget > 0 ? Math.round((data.tokens / totalBudget) * 100) : 0;
+    const maxPct = DEFAULT_CATEGORY_MAX_PCT[category];
+    return {
+      category,
+      tokens: data.tokens,
+      percentage,
+      itemCount: data.count,
+      isOverBudget: typeof maxPct === 'number' ? percentage > maxPct : false,
+    };
+  });
+}
+
+/**
+ * Options controlling unload-candidate selection.
+ */
+export interface UnloadCandidateOptions {
+  /** Priorities eligible for auto-unload (critical is always excluded). */
+  eligiblePriorities: ContextItemPriority[];
+  /** Minimum access count before an item is eligible. */
+  minAccessCount: number;
+  /** Minimum ms since last access before an item is eligible. */
+  minTimeSinceAccess: number;
+  /** Reference "now" for time-since-access checks (defaults to Date.now()). */
+  now?: number;
+}
+
+/**
+ * Select the set of loaded items to unload in order to free at least
+ * `tokensNeeded` tokens, honoring priority (lowest first), recency (oldest
+ * first), and eligibility rules. Critical items are never selected.
+ *
+ * Returns the ordered list of items to unload (may free more than needed by the
+ * granularity of the last item, or fewer if not enough eligible items exist).
+ */
+export function findUnloadCandidates<T extends BudgetItemInput>(
+  items: T[],
+  tokensNeeded: number,
+  options: UnloadCandidateOptions
+): T[] {
+  const now = options.now ?? Date.now();
+  const candidates: T[] = [];
+  let freed = 0;
+
+  const sorted = [...items].sort((a, b) => {
+    const aPriority = PRIORITY_SCORES[a.priority as ContextItemPriority] ?? 0;
+    const bPriority = PRIORITY_SCORES[b.priority as ContextItemPriority] ?? 0;
+    if (aPriority !== bPriority) return aPriority - bPriority; // lowest priority first
+
+    const aTime = a.lastAccessedAt ? new Date(a.lastAccessedAt).getTime() : 0;
+    const bTime = b.lastAccessedAt ? new Date(b.lastAccessedAt).getTime() : 0;
+    return aTime - bTime; // oldest first
+  });
+
+  for (const item of sorted) {
+    if (item.priority === 'critical') continue;
+
+    const timeSinceAccess = item.lastAccessedAt
+      ? now - new Date(item.lastAccessedAt).getTime()
+      : Infinity;
+
+    const eligible =
+      options.eligiblePriorities.includes(item.priority as ContextItemPriority) &&
+      (item.accessCount ?? 0) >= options.minAccessCount &&
+      timeSinceAccess >= options.minTimeSinceAccess;
+
+    if (!eligible) continue;
+
+    candidates.push(item);
+    freed += item.tokenCost || 0;
+    if (freed >= tokensNeeded) break;
+  }
+
+  return candidates;
+}
+
+/**
+ * Options for generating optimization suggestions.
+ */
+export interface OptimizationOptions {
+  aggressiveness?: 'conservative' | 'moderate' | 'aggressive';
+  compressionEnabled?: boolean;
+  compressionThreshold?: number;
+  now?: number;
+}
+
+/**
+ * Generate ranked optimization suggestions (unload / compress / summarize /
+ * consolidate) for a set of loaded items. Pure and deterministic given `now`.
+ */
+export function generateOptimizationSuggestions(
+  items: BudgetItemInput[],
+  options: OptimizationOptions = {}
+): OptimizationSuggestion[] {
+  const {
+    aggressiveness = 'moderate',
+    compressionEnabled = true,
+    compressionThreshold = 2000,
+    now = Date.now(),
+  } = options;
+
+  const suggestions: OptimizationSuggestion[] = [];
+
+  const asContextItem = (item: BudgetItemInput): ContextItem => ({
+    id: item.id ?? '',
+    type: item.type as ContextItemType,
+    name: item.name ?? '',
+    tokenCost: item.tokenCost,
+    priority: item.priority as ContextItemPriority,
+    status: (item.status as ContextItem['status']) ?? 'loaded',
+    lastAccessedAt: item.lastAccessedAt ?? undefined,
+    accessCount: item.accessCount,
+    metadata: item.metadata,
+  });
+
+  // 1. Unload rarely accessed, non-critical items.
+  const lowAccessThreshold =
+    aggressiveness === 'conservative' ? 0 : aggressiveness === 'moderate' ? 1 : 2;
+  const lowAccessItems = items.filter(
+    (item) => (item.accessCount ?? 0) <= lowAccessThreshold && item.priority !== 'critical'
+  );
+  if (lowAccessItems.length > 0) {
+    suggestions.push({
+      type: 'unload',
+      priority: 'high',
+      description: `Unload ${lowAccessItems.length} rarely accessed items`,
+      affectedItems: lowAccessItems.map(asContextItem),
+      estimatedSavings: lowAccessItems.reduce((sum, i) => sum + (i.tokenCost || 0), 0),
+      confidence: 0.9,
+      autoApplicable: aggressiveness === 'aggressive',
+      reasoning: `These items have been accessed ${lowAccessThreshold} or fewer times`,
+    });
+  }
+
+  // 2. Compress large files.
+  if (compressionEnabled) {
+    const largeFiles = items.filter(
+      (item) =>
+        item.type === 'file' &&
+        item.tokenCost >= compressionThreshold &&
+        !item.metadata?.compressed
+    );
+    if (largeFiles.length > 0) {
+      suggestions.push({
+        type: 'compress',
+        priority: 'medium',
+        description: `Compress ${largeFiles.length} large files`,
+        affectedItems: largeFiles.map(asContextItem),
+        estimatedSavings: Math.round(
+          largeFiles.reduce((sum, i) => sum + (i.tokenCost || 0), 0) * 0.6
+        ),
+        confidence: 0.75,
+        autoApplicable: false,
+        reasoning: `Files over ${compressionThreshold} tokens can be compressed`,
+      });
+    }
+  }
+
+  // 3. Summarize old messages.
+  const oldMessages = items.filter(
+    (item) =>
+      item.type === 'message' &&
+      item.lastAccessedAt &&
+      now - new Date(item.lastAccessedAt).getTime() > 600000 // 10 minutes
+  );
+  if (oldMessages.length > 2) {
+    suggestions.push({
+      type: 'summarize',
+      priority: 'medium',
+      description: `Summarize ${oldMessages.length} old messages`,
+      affectedItems: oldMessages.map(asContextItem),
+      estimatedSavings: Math.round(
+        oldMessages.reduce((sum, i) => sum + (i.tokenCost || 0), 0) * 0.7
+      ),
+      confidence: 0.8,
+      autoApplicable: false,
+      reasoning: 'Old messages can be summarized to save tokens while preserving context',
+    });
+  }
+
+  // 4. Consolidate similar skills.
+  const skills = items.filter((item) => item.type === 'skill');
+  const byCategory = new Map<string, BudgetItemInput[]>();
+  for (const skill of skills) {
+    const category = skill.metadata?.summary || 'general';
+    if (!byCategory.has(category)) byCategory.set(category, []);
+    byCategory.get(category)!.push(skill);
+  }
+  for (const [category, categorySkills] of byCategory) {
+    if (categorySkills.length > 3) {
+      suggestions.push({
+        type: 'consolidate',
+        priority: 'low',
+        description: `Consolidate ${categorySkills.length} ${category} skills`,
+        affectedItems: categorySkills.map(asContextItem),
+        estimatedSavings: Math.round(
+          categorySkills.reduce((sum, i) => sum + (i.tokenCost || 0), 0) * 0.3
+        ),
+        confidence: 0.6,
+        autoApplicable: false,
+        reasoning: 'Multiple similar skills can potentially be consolidated',
+      });
+    }
+  }
+
+  const priorityOrder = { high: 0, medium: 1, low: 2 } as const;
+  return suggestions.sort((a, b) => priorityOrder[a.priority] - priorityOrder[b.priority]);
+}

--- a/lib/services/context-budget.service.ts
+++ b/lib/services/context-budget.service.ts
@@ -22,6 +22,15 @@ import {
 import { eq, and, desc, sql } from 'drizzle-orm';
 import { estimateTokens } from './token-counter.service';
 import { logger } from '../logger';
+import {
+  PRIORITY_SCORES,
+  calculatePriorityScore as calcPriorityScore,
+  calculateAllocations as calcAllocations,
+  mapTypeToCategory as mapTypeToCategoryPure,
+  findUnloadCandidates as findUnloadCandidatesPure,
+  generateOptimizationSuggestions as generateOptimizationSuggestionsPure,
+  type BudgetItemInput,
+} from './context-budget-logic';
 import type {
   ContextBudget,
   ContextItem,
@@ -78,16 +87,6 @@ const DEFAULT_BUDGET_CONFIG: BudgetConfig = {
     history: { maxPercentage: 20, priority: 60 },
     other: { maxPercentage: 10, priority: 50 },
   },
-};
-
-/**
- * Priority scores for loading decisions
- */
-const PRIORITY_SCORES: Record<ContextItemPriority, number> = {
-  critical: 100,
-  high: 75,
-  medium: 50,
-  low: 25,
 };
 
 export class ContextBudgetService {
@@ -344,8 +343,6 @@ export class ContextBudgetService {
     userId: string,
     aggressiveness: 'conservative' | 'moderate' | 'aggressive' = 'moderate'
   ): Promise<OptimizationSuggestion[]> {
-    const suggestions: OptimizationSuggestion[] = [];
-
     // Get loaded items
     const items = await db.query.context_items.findMany({
       where: and(
@@ -354,111 +351,17 @@ export class ContextBudgetService {
       ),
     });
 
-    const budget = await this.getBudget(sessionId, userId);
     const config = await this.getUserConfig(userId);
 
-    // Suggestion 1: Unload low-access items
-    const lowAccessThreshold = aggressiveness === 'conservative' ? 0 : aggressiveness === 'moderate' ? 1 : 2;
-    const lowAccessItems = items.filter(
-      (item) =>
-        (item.access_count || 0) <= lowAccessThreshold &&
-        item.priority !== 'critical'
+    // Delegate to the pure, unit-tested logic module.
+    return generateOptimizationSuggestionsPure(
+      items.map((i: any) => this.dbItemToBudgetInput(i)),
+      {
+        aggressiveness,
+        compressionEnabled: config.compression.enabled,
+        compressionThreshold: config.compression.compressionThreshold,
+      }
     );
-
-    if (lowAccessItems.length > 0) {
-      suggestions.push({
-        type: 'unload',
-        priority: 'high',
-        description: `Unload ${lowAccessItems.length} rarely accessed items`,
-        affectedItems: lowAccessItems.map(this.mapDbItemToContextItem),
-        estimatedSavings: lowAccessItems.reduce((sum, item) => sum + item.token_cost, 0),
-        confidence: 0.9,
-        autoApplicable: aggressiveness === 'aggressive',
-        reasoning: `These items have been accessed ${lowAccessThreshold} or fewer times`,
-      });
-    }
-
-    // Suggestion 2: Compress large files
-    if (config.compression.enabled) {
-      const largeFiles = items.filter(
-        (item) =>
-          item.type === 'file' &&
-          item.token_cost >= config.compression.compressionThreshold &&
-          !item.metadata?.compressed
-      );
-
-      if (largeFiles.length > 0) {
-        suggestions.push({
-          type: 'compress',
-          priority: 'medium',
-          description: `Compress ${largeFiles.length} large files`,
-          affectedItems: largeFiles.map(this.mapDbItemToContextItem),
-          estimatedSavings: Math.round(
-            largeFiles.reduce((sum, item) => sum + item.token_cost, 0) * 0.6
-          ),
-          confidence: 0.75,
-          autoApplicable: config.compression.autoCompress,
-          reasoning: `Files over ${config.compression.compressionThreshold} tokens can be compressed`,
-        });
-      }
-    }
-
-    // Suggestion 3: Summarize old messages
-    const oldMessages = items.filter(
-      (item) =>
-        item.type === 'message' &&
-        item.last_accessed_at &&
-        Date.now() - item.last_accessed_at.getTime() > 600000 // 10 minutes
-    );
-
-    if (oldMessages.length > 2) {
-      suggestions.push({
-        type: 'summarize',
-        priority: 'medium',
-        description: `Summarize ${oldMessages.length} old messages`,
-        affectedItems: oldMessages.map(this.mapDbItemToContextItem),
-        estimatedSavings: Math.round(
-          oldMessages.reduce((sum, item) => sum + item.token_cost, 0) * 0.7
-        ),
-        confidence: 0.8,
-        autoApplicable: false,
-        reasoning: 'Old messages can be summarized to save tokens while preserving context',
-      });
-    }
-
-    // Suggestion 4: Consolidate skills
-    const skills = items.filter((item) => item.type === 'skill');
-    const skillsByCategory = new Map<string, typeof items>();
-
-    skills.forEach((skill) => {
-      const category = skill.metadata?.summary || 'general';
-      if (!skillsByCategory.has(category)) {
-        skillsByCategory.set(category, []);
-      }
-      skillsByCategory.get(category)!.push(skill);
-    });
-
-    for (const [category, categorySkills] of skillsByCategory) {
-      if (categorySkills.length > 3) {
-        suggestions.push({
-          type: 'consolidate',
-          priority: 'low',
-          description: `Consolidate ${categorySkills.length} ${category} skills`,
-          affectedItems: categorySkills.map(this.mapDbItemToContextItem),
-          estimatedSavings: Math.round(
-            categorySkills.reduce((sum, item) => sum + item.token_cost, 0) * 0.3
-          ),
-          confidence: 0.6,
-          autoApplicable: false,
-          reasoning: 'Multiple similar skills can potentially be consolidated',
-        });
-      }
-    }
-
-    return suggestions.sort((a, b) => {
-      const priorityOrder = { high: 0, medium: 1, low: 2 };
-      return priorityOrder[a.priority] - priorityOrder[b.priority];
-    });
   }
 
   /**
@@ -582,47 +485,33 @@ export class ContextBudgetService {
     tokensNeeded: number,
     config: BudgetConfig
   ): any[] {
-    const candidates: any[] = [];
-    let freedTokens = 0;
-    const now = Date.now();
-
-    // Sort by priority (low first) and last access time
-    const sorted = [...items].sort((a, b) => {
-      const aPriority = PRIORITY_SCORES[a.priority as ContextItemPriority] || 0;
-      const bPriority = PRIORITY_SCORES[b.priority as ContextItemPriority] || 0;
-
-      if (aPriority !== bPriority) {
-        return aPriority - bPriority; // Lower priority first
-      }
-
-      const aTime = a.last_accessed_at?.getTime() || 0;
-      const bTime = b.last_accessed_at?.getTime() || 0;
-      return aTime - bTime; // Older first
+    // Delegate to the pure logic, preserving the original DB rows so callers
+    // can continue to read snake_case fields (id, token_cost) on the result.
+    const inputs = items.map((i) => ({ ...this.dbItemToBudgetInput(i), __row: i }));
+    const chosen = findUnloadCandidatesPure(inputs as any, tokensNeeded, {
+      eligiblePriorities: config.autoUnload.priorities,
+      minAccessCount: config.autoUnload.minAccessCount,
+      minTimeSinceAccess: config.autoUnload.minTimeSinceAccess,
     });
+    return chosen.map((c: any) => c.__row);
+  }
 
-    for (const item of sorted) {
-      // Skip critical items
-      if (item.priority === 'critical') continue;
-
-      // Check if eligible for auto-unload
-      const timeSinceAccess = item.last_accessed_at
-        ? now - item.last_accessed_at.getTime()
-        : Infinity;
-
-      const isEligible =
-        config.autoUnload.priorities.includes(item.priority) &&
-        (item.access_count || 0) >= config.autoUnload.minAccessCount &&
-        timeSinceAccess >= config.autoUnload.minTimeSinceAccess;
-
-      if (!isEligible) continue;
-
-      candidates.push(item);
-      freedTokens += item.token_cost;
-
-      if (freedTokens >= tokensNeeded) break;
-    }
-
-    return candidates;
+  /**
+   * Normalize a Drizzle context_items row to the DB-agnostic BudgetItemInput
+   * consumed by the pure logic module.
+   */
+  private dbItemToBudgetInput(row: any): BudgetItemInput {
+    return {
+      id: row.id,
+      type: row.type,
+      name: row.name,
+      tokenCost: row.token_cost,
+      priority: row.priority,
+      status: row.status,
+      accessCount: row.access_count,
+      lastAccessedAt: row.last_accessed_at,
+      metadata: row.metadata,
+    };
   }
 
   /**
@@ -632,33 +521,7 @@ export class ContextBudgetService {
     item: Omit<ContextItem, 'id' | 'status' | 'loadedAt'>,
     budget: ContextBudget
   ): number {
-    let score = PRIORITY_SCORES[item.priority] || 0;
-
-    // Adjust for budget state
-    if (budget.isCritical) {
-      score *= 0.5; // Penalize loading in critical state
-    } else if (budget.isWarning) {
-      score *= 0.75; // Penalize loading in warning state
-    }
-
-    // Adjust for type importance
-    const typeBonus: Record<ContextItemType, number> = {
-      baseline: 20,
-      skill: 15,
-      tool: 10,
-      file: 5,
-      message: 3,
-      history: 1,
-    };
-
-    score += typeBonus[item.type] || 0;
-
-    // Penalize expensive items
-    if (item.tokenCost > 5000) {
-      score -= 10;
-    }
-
-    return score;
+    return calcPriorityScore(item, budget);
   }
 
   /**
@@ -668,59 +531,17 @@ export class ContextBudgetService {
     items: any[],
     totalBudget: number
   ): BudgetAllocation[] {
-    const categories: Map<BudgetCategory, { tokens: number; count: number }> = new Map();
-
-    // Initialize all categories
-    const allCategories: BudgetCategory[] = [
-      'baseline',
-      'skills',
-      'files',
-      'history',
-      'tools',
-      'other',
-    ];
-
-    allCategories.forEach((cat) => {
-      categories.set(cat, { tokens: 0, count: 0 });
-    });
-
-    // Aggregate by category
-    items.forEach((item) => {
-      const category = this.mapTypeToCategory(item.type);
-      const current = categories.get(category)!;
-      current.tokens += item.token_cost;
-      current.count += 1;
-    });
-
-    // Build allocations
-    return Array.from(categories.entries()).map(([category, data]) => ({
-      category,
-      tokens: data.tokens,
-      percentage: totalBudget > 0 ? Math.round((data.tokens / totalBudget) * 100) : 0,
-      itemCount: data.count,
-      isOverBudget: (() => {
-        const pref = DEFAULT_BUDGET_CONFIG.categoryPreferences[category];
-        if (!pref) return false;
-        const percentage = totalBudget > 0 ? Math.round((data.tokens / totalBudget) * 100) : 0;
-        return percentage > pref.maxPercentage;
-      })(),
-    }));
+    return calcAllocations(
+      items.map((i) => this.dbItemToBudgetInput(i)),
+      totalBudget
+    );
   }
 
   /**
    * Map item type to budget category
    */
   private mapTypeToCategory(type: string): BudgetCategory {
-    const mapping: Record<string, BudgetCategory> = {
-      skill: 'skills',
-      file: 'files',
-      message: 'history',
-      history: 'history',
-      tool: 'tools',
-      baseline: 'baseline',
-    };
-
-    return mapping[type] || 'other';
+    return mapTypeToCategoryPure(type);
   }
 
   /**


### PR DESCRIPTION
## Summary

Closes #20 — Context Budget Manager.

The Context Budget Manager (data model, API routes, service, UI components, and demo page) already lands in the repo. This PR **hardens** it into a production-ready state by making the core budgeting math genuinely testable and fixing a real query bug:

- **Extract pure logic** into `lib/services/context-budget-logic.ts` — framework/DB-agnostic, deterministic functions for:
  - budget-state derivation (used/remaining/percentage + 80% warning / 95% critical thresholds, with clamping so remaining is never negative)
  - `canLoad` pre-load gating
  - smart-loading priority scoring (priority + budget-pressure + type bonus + expensive-item penalty)
  - per-category allocation breakdown (always all six categories, over-budget flagging)
  - unload-candidate selection (lowest-priority + stalest first, never touches `critical`, honors eligibility rules)
  - optimization-suggestion generation (unload / compress / summarize / consolidate, ranked)
- **Refactor `context-budget.service.ts`** to delegate to the shared logic, removing ~180 lines of duplicated in-service math so the server and the tests share one source of truth.
- **Fix `/api/context/budget` history query**: it filtered `budget_events` on `context_items.session_id` instead of `budget_events.session_id`, so `?includeHistory=true` returned incorrect events.

### Acceptance criteria (Must Have) — covered
- Real-time token usage tracking (service + `/api/context/track`)
- Budget meter UI + visual breakdown (`components/context-budget/*`, `/context-budget-demo`)
- Pre-load cost calculation (`/api/context/preload-cost`, `canLoad`)
- Budget threshold alerts (80% warning / 95% critical)
- Optimization suggestions (`/api/context/optimize`)
- Auto-unload of unused/low-priority items (`findUnloadCandidates`)

## Test evidence

`pnpm exec vitest run __tests__/services/context-budget-logic.test.ts __tests__/services/context-budget.service.test.ts`
```
✓ __tests__/services/context-budget.service.test.ts (5 tests)
✓ __tests__/services/context-budget-logic.test.ts (28 tests)
 Test Files  2 passed (2)
      Tests  33 passed (33)
```

Full suite (`pnpm test`): **583 passed, 30 skipped**. The only 2 failures are pre-existing and unrelated to this change (verified by stashing these edits and re-running on the base commit):
- `__tests__/unit/subagents.test.ts` — requires `ANTHROPIC_API_KEY` env var
- `__tests__/services/agent-skill.service.test.ts` — flaky `searchTime > 0` timing assertion

## Build evidence

`pnpm build` (next build) — **succeeded**. Relevant routes emitted:
```
ƒ /api/context/budget
ƒ /api/context/optimize
ƒ /api/context/preload-cost
ƒ /api/context/track
ƒ /api/context/unload
○ /context-budget-demo    115 kB   307 kB
```

## Files changed
- `lib/services/context-budget-logic.ts` (new, pure logic)
- `__tests__/services/context-budget-logic.test.ts` (new, 28 cases)
- `lib/services/context-budget.service.ts` (delegate to shared logic)
- `app/api/context/budget/route.ts` (history-query fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)