### PR TITLE
feat(fullstack): infer + auto-provision ZeroDB backend from prompt (#36)

### DIFF
--- a/__tests__/services/fullstack-generator.service.test.ts
+++ b/__tests__/services/fullstack-generator.service.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest'
+import {
+  generateBackend,
+  endpointsForTable,
+  buildAuthScaffold,
+  buildClientSdk,
+} from '@/lib/services/fullstack-generator.service'
+import { inferSchema } from '@/lib/services/schema-inference.service'
+
+/**
+ * Tests for the full-stack orchestrator (Issue #36). All tests use dryRun so no
+ * network / ZeroDB calls are made; provisioning results are asserted as skipped.
+ */
+describe('fullstack-generator: endpointsForTable', () => {
+  it('emits the five CRUD endpoints for a table', () => {
+    const eps = endpointsForTable('tasks')
+    const methods = eps.map((e) => e.method)
+    expect(methods).toEqual(expect.arrayContaining(['GET', 'POST', 'PUT', 'DELETE']))
+    expect(eps.every((e) => e.path.includes('/api/db/tasks'))).toBe(true)
+  })
+})
+
+describe('fullstack-generator: buildAuthScaffold', () => {
+  it('returns null when auth is not required', () => {
+    const schema = inferSchema('a public product catalog')
+    expect(buildAuthScaffold(schema)).toBeNull()
+  })
+
+  it('returns auth endpoints when auth is required', () => {
+    const schema = inferSchema('users log in to manage tasks')
+    const auth = buildAuthScaffold(schema)
+    expect(auth).not.toBeNull()
+    expect(auth!.enabled).toBe(true)
+    const paths = auth!.endpoints.map((e) => e.path)
+    expect(paths).toEqual(
+      expect.arrayContaining([
+        '/api/auth/signup',
+        '/api/auth/login',
+        '/api/auth/me',
+      ])
+    )
+  })
+})
+
+describe('fullstack-generator: buildClientSdk', () => {
+  it('generates a typed client with a TableName union of provisioned tables', () => {
+    const schema = inferSchema('manage tasks and notes')
+    const sdk = buildClientSdk(schema)
+    expect(sdk).toContain('export const db')
+    expect(sdk).toContain("'tasks'")
+    expect(sdk).toContain("'notes'")
+    expect(sdk).toContain('async create(')
+    expect(sdk).toContain('/api/db/')
+  })
+
+  it('does not leak an API key into the client', () => {
+    const schema = inferSchema('tasks')
+    const sdk = buildClientSdk(schema)
+    expect(sdk.toLowerCase()).not.toContain('api-key')
+    expect(sdk.toLowerCase()).not.toContain('x-api-key')
+  })
+})
+
+describe('fullstack-generator: generateBackend (dry run)', () => {
+  it('returns schema, endpoints, and a skipped provisioning result per table', async () => {
+    const result = await generateBackend('a todo app to manage tasks', { dryRun: true })
+    expect(result.schema.tables.length).toBeGreaterThan(0)
+    expect(result.provisioned.every((p) => p.status === 'skipped')).toBe(true)
+    // one provision entry per table
+    expect(result.provisioned).toHaveLength(result.schema.tables.length)
+    // CRUD endpoints present for the tasks table
+    expect(result.endpoints.some((e) => e.path.includes('/api/db/tasks'))).toBe(true)
+  })
+
+  it('includes auth endpoints and scaffold when the prompt needs auth', async () => {
+    const result = await generateBackend('users log in and manage their tasks', {
+      dryRun: true,
+    })
+    expect(result.auth).not.toBeNull()
+    expect(result.endpoints.some((e) => e.path === '/api/auth/login')).toBe(true)
+  })
+
+  it('omits auth scaffold for anonymous apps', async () => {
+    const result = await generateBackend('a public product catalog', { dryRun: true })
+    expect(result.auth).toBeNull()
+    expect(result.endpoints.some((e) => e.path.startsWith('/api/auth'))).toBe(false)
+  })
+
+  it('uses the provided projectId', async () => {
+    const result = await generateBackend('tasks', {
+      dryRun: true,
+      projectId: 'proj-123',
+    })
+    expect(result.projectId).toBe('proj-123')
+  })
+
+  it('produces a human-readable summary', async () => {
+    const result = await generateBackend('manage tasks', { dryRun: true })
+    expect(result.summary).toMatch(/table/i)
+  })
+})

--- a/__tests__/services/schema-inference.service.test.ts
+++ b/__tests__/services/schema-inference.service.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from 'vitest'
+import {
+  inferSchema,
+  extractEntities,
+  detectAuthRequirement,
+  detectVectorRequirement,
+  toSnakeCase,
+  singularize,
+  pluralize,
+  describeSchema,
+} from '@/lib/services/schema-inference.service'
+
+/**
+ * Unit tests for the pure schema-inference layer (Issue #36).
+ * These cover the deterministic prompt -> data-model transformation that drives
+ * full-stack backend provisioning.
+ */
+describe('schema-inference: helpers', () => {
+  describe('toSnakeCase', () => {
+    it('lowercases and snake-cases camelCase', () => {
+      expect(toSnakeCase('BlogPost')).toBe('blog_post')
+      expect(toSnakeCase('userProfile')).toBe('user_profile')
+    })
+    it('collapses spaces and hyphens', () => {
+      expect(toSnakeCase('  order   items ')).toBe('order_items')
+      expect(toSnakeCase('to-do-list')).toBe('to_do_list')
+    })
+    it('strips invalid characters', () => {
+      expect(toSnakeCase('price$ (usd)')).toBe('price_usd')
+    })
+  })
+
+  describe('pluralize / singularize', () => {
+    it('handles regular plurals', () => {
+      expect(pluralize('task')).toBe('tasks')
+      expect(singularize('tasks')).toBe('task')
+    })
+    it('handles -y -> -ies', () => {
+      expect(pluralize('category')).toBe('categories')
+      expect(singularize('categories')).toBe('category')
+    })
+    it('handles sibilant endings', () => {
+      expect(pluralize('box')).toBe('boxes')
+      expect(pluralize('class')).toBe('classes')
+    })
+    it('handles irregulars', () => {
+      expect(pluralize('person')).toBe('people')
+      expect(singularize('people')).toBe('person')
+    })
+  })
+
+  describe('detectAuthRequirement', () => {
+    it('detects explicit auth language', () => {
+      expect(detectAuthRequirement('an app with login and signup')).toBe(true)
+      expect(detectAuthRequirement('users need to register with a password')).toBe(true)
+    })
+    it('detects personalization cues', () => {
+      expect(detectAuthRequirement('a place to store my notes')).toBe(true)
+      expect(detectAuthRequirement("show each user's tasks")).toBe(true)
+    })
+    it('returns false for anonymous apps', () => {
+      expect(detectAuthRequirement('a public product catalog')).toBe(false)
+    })
+  })
+
+  describe('detectVectorRequirement', () => {
+    it('detects semantic/vector search language', () => {
+      expect(detectVectorRequirement('add semantic search over docs')).toBe(true)
+      expect(detectVectorRequirement('a RAG chatbot')).toBe(true)
+    })
+    it('returns false otherwise', () => {
+      expect(detectVectorRequirement('a simple todo list')).toBe(false)
+    })
+  })
+})
+
+describe('schema-inference: extractEntities', () => {
+  it('picks up known entities in singular or plural form', () => {
+    expect(extractEntities('a todo app to manage tasks')).toContain('task')
+    expect(extractEntities('build a blog with posts')).toContain('post')
+  })
+
+  it('extracts multiple distinct entities', () => {
+    const entities = extractEntities('store customers and their orders and products')
+    expect(entities).toEqual(expect.arrayContaining(['customer', 'order', 'product']))
+  })
+
+  it('de-duplicates repeated mentions', () => {
+    const entities = extractEntities('tasks tasks and more tasks')
+    expect(entities.filter((e) => e === 'task')).toHaveLength(1)
+  })
+
+  it('filters noise words like app / dashboard / page', () => {
+    const entities = extractEntities('a dashboard app page interface')
+    expect(entities).not.toContain('dashboard')
+    expect(entities).not.toContain('app')
+    expect(entities).not.toContain('page')
+  })
+
+  it('falls back to generic plural nouns not in the library', () => {
+    const entities = extractEntities('track widgets in a warehouse')
+    expect(entities).toContain('widget')
+  })
+})
+
+describe('schema-inference: inferSchema', () => {
+  it('builds a table with system columns for a simple prompt', () => {
+    const schema = inferSchema('a todo app to manage tasks')
+    const tasks = schema.tables.find((t) => t.name === 'tasks')
+    expect(tasks).toBeDefined()
+    const colNames = tasks!.columns.map((c) => c.name)
+    expect(colNames).toContain('id')
+    expect(colNames).toContain('created_at')
+    expect(colNames).toContain('updated_at')
+    expect(colNames).toContain('title')
+  })
+
+  it('adds a users table and user_id scoping when auth is required', () => {
+    const schema = inferSchema('an app where users log in and manage their own tasks')
+    expect(schema.requiresAuth).toBe(true)
+    expect(schema.tables.some((t) => t.name === 'users')).toBe(true)
+    const tasks = schema.tables.find((t) => t.name === 'tasks')!
+    expect(tasks.userScoped).toBe(true)
+    const userId = tasks.columns.find((c) => c.name === 'user_id')
+    expect(userId).toBeDefined()
+    expect(userId!.references).toEqual({ table: 'users', column: 'id' })
+  })
+
+  it('never double-scopes the users table itself', () => {
+    const schema = inferSchema('users login system', { requireAuth: true })
+    const users = schema.tables.find((t) => t.name === 'users')!
+    expect(users.userScoped).toBe(false)
+    expect(users.columns.some((c) => c.name === 'user_id')).toBe(false)
+  })
+
+  it('honors an explicit requireAuth override', () => {
+    const schema = inferSchema('a public product catalog', { requireAuth: true })
+    expect(schema.requiresAuth).toBe(true)
+    expect(schema.tables.some((t) => t.name === 'users')).toBe(true)
+  })
+
+  it('detects vector search requirement', () => {
+    const schema = inferSchema('notes app with semantic search')
+    expect(schema.requiresVectorSearch).toBe(true)
+    expect(schema.notes.join(' ')).toMatch(/semantic search/i)
+  })
+
+  it('falls back to a generic items table when no entities are found', () => {
+    const schema = inferSchema('make me something cool')
+    expect(schema.tables).toHaveLength(1)
+    expect(schema.tables[0].name).toBe('items')
+  })
+
+  it('respects the maxTables cap', () => {
+    const schema = inferSchema(
+      'customers orders products invoices bookings events comments messages projects',
+      { maxTables: 3 }
+    )
+    expect(schema.tables.length).toBeLessThanOrEqual(3)
+    expect(schema.notes.join(' ')).toMatch(/capped/i)
+  })
+
+  it('marks unique columns from the entity library', () => {
+    const schema = inferSchema('a customer directory')
+    const customers = schema.tables.find((t) => t.name === 'customers')!
+    const email = customers.columns.find((c) => c.name === 'email')!
+    expect(email.unique).toBe(true)
+  })
+
+  it('is deterministic for the same prompt', () => {
+    const a = inferSchema('manage tasks and projects with login')
+    const b = inferSchema('manage tasks and projects with login')
+    expect(JSON.stringify(a)).toEqual(JSON.stringify(b))
+  })
+})
+
+describe('schema-inference: describeSchema', () => {
+  it('summarizes tables, auth, and vector search', () => {
+    const schema = inferSchema('tasks with login and semantic search')
+    const text = describeSchema(schema)
+    expect(text).toMatch(/table/i)
+    expect(text).toMatch(/authentication/i)
+    expect(text).toMatch(/vector search/i)
+    expect(text).toMatch(/tasks/)
+  })
+})

--- a/app/api/fullstack/provision/route.ts
+++ b/app/api/fullstack/provision/route.ts
@@ -1,0 +1,86 @@
+/**
+ * Full-Stack Provision API (Issue #36)
+ *
+ * POST /api/fullstack/provision
+ *   Body: { prompt: string, requireAuth?: boolean, dryRun?: boolean,
+ *           projectId?: string, maxTables?: number }
+ *
+ * Infers a backend data model from the prompt, auto-provisions ZeroDB tables,
+ * and returns the API endpoints, auth scaffold, and a drop-in TypeScript client
+ * for the generated UI. This is the backend half of full-stack generation.
+ *
+ * GET /api/fullstack/provision?prompt=...
+ *   Convenience preview (always a dry run — never provisions).
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { generateBackend } from '@/lib/services/fullstack-generator.service'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+export const maxDuration = 60
+
+const bodySchema = z.object({
+  prompt: z.string().min(1, 'prompt is required').max(4000),
+  requireAuth: z.boolean().optional(),
+  dryRun: z.boolean().optional(),
+  projectId: z.string().optional(),
+  maxTables: z.number().int().positive().max(20).optional(),
+})
+
+export async function POST(request: NextRequest) {
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const parsed = bodySchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Invalid request', details: parsed.error.issues },
+      { status: 400 }
+    )
+  }
+
+  try {
+    const result = await generateBackend(parsed.data.prompt, {
+      requireAuth: parsed.data.requireAuth,
+      dryRun: parsed.data.dryRun,
+      projectId: parsed.data.projectId,
+      maxTables: parsed.data.maxTables,
+    })
+    return NextResponse.json(result, { status: 200 })
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: 'Backend provisioning failed',
+        detail: error instanceof Error ? error.message : 'unknown error',
+      },
+      { status: 500 }
+    )
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const prompt = request.nextUrl.searchParams.get('prompt')
+  if (!prompt) {
+    return NextResponse.json({ error: 'prompt query param required' }, { status: 400 })
+  }
+
+  try {
+    // GET is always a preview; never touch the database.
+    const result = await generateBackend(prompt, { dryRun: true })
+    return NextResponse.json(result, { status: 200 })
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: 'Backend preview failed',
+        detail: error instanceof Error ? error.message : 'unknown error',
+      },
+      { status: 500 }
+    )
+  }
+}

--- a/lib/services/fullstack-generator.service.ts
+++ b/lib/services/fullstack-generator.service.ts
@@ -1,0 +1,260 @@
+/**
+ * Full-Stack Generator Service (Issue #36)
+ *
+ * Orchestrates the "UI-only -> full-stack" upgrade:
+ *   prompt --> infer schema --> provision ZeroDB tables --> emit API + auth +
+ *   client-SDK artifacts the generated UI can consume.
+ *
+ * The inference layer (schema-inference.service) is pure; this layer is where
+ * the side effects live (ZeroDB REST calls). Provisioning is best-effort and
+ * idempotent: ZeroDB auto-creates tables on first insert, so a failed create
+ * call never blocks generation — we surface it in the result instead.
+ */
+
+import {
+  inferSchema,
+  describeSchema,
+  InferredSchema,
+  InferredTable,
+  InferenceOptions,
+} from './schema-inference.service'
+import { logger } from '../logger'
+
+const ZERODB_API = process.env.ZERODB_API_BASE_URL || 'https://api.ainative.studio/api'
+const DEFAULT_PROJECT_ID =
+  process.env.ZERODB_PROJECT_ID || '5dfbc60c-7463-4e21-ac68-9bbe536f9adf'
+const API_KEY = process.env.ZERODB_API_KEY || ''
+
+/** REST endpoint descriptor for a provisioned table (as exposed via /api/db). */
+export interface ApiEndpoint {
+  method: 'GET' | 'POST' | 'PUT' | 'DELETE'
+  path: string
+  description: string
+}
+
+/** Result of provisioning a single table. */
+export interface TableProvisionResult {
+  table: string
+  status: 'created' | 'exists' | 'skipped' | 'failed'
+  detail?: string
+}
+
+/** Complete result of a full-stack generation request. */
+export interface FullStackResult {
+  schema: InferredSchema
+  summary: string
+  projectId: string
+  provisioned: TableProvisionResult[]
+  endpoints: ApiEndpoint[]
+  /** Ready-to-embed TypeScript client for the generated UI. */
+  clientSdk: string
+  /** Auth scaffold info (present only when the schema requires auth). */
+  auth: AuthScaffold | null
+}
+
+/** Auth scaffold surfaced to the generated app. */
+export interface AuthScaffold {
+  enabled: boolean
+  provider: 'ainative'
+  endpoints: ApiEndpoint[]
+  note: string
+}
+
+export interface GenerateBackendOptions extends InferenceOptions {
+  /** Override the ZeroDB project to provision into. */
+  projectId?: string
+  /** Skip network provisioning (dry run) — used in tests/preview. */
+  dryRun?: boolean
+}
+
+/** Build the /api/db endpoint descriptors for one table. */
+export function endpointsForTable(table: string): ApiEndpoint[] {
+  return [
+    { method: 'GET', path: `/api/db/${table}`, description: `List ${table}` },
+    {
+      method: 'GET',
+      path: `/api/db/${table}?filter={...}`,
+      description: `Query ${table} with filters`,
+    },
+    { method: 'POST', path: `/api/db/${table}`, description: `Create a ${table} row` },
+    {
+      method: 'PUT',
+      path: `/api/db/${table}?id={id}`,
+      description: `Update a ${table} row`,
+    },
+    {
+      method: 'DELETE',
+      path: `/api/db/${table}?id={id}`,
+      description: `Delete a ${table} row`,
+    },
+  ]
+}
+
+/** Build the auth scaffold descriptor when the schema requires auth. */
+export function buildAuthScaffold(schema: InferredSchema): AuthScaffold | null {
+  if (!schema.requiresAuth) return null
+  return {
+    enabled: true,
+    provider: 'ainative',
+    endpoints: [
+      { method: 'POST', path: '/api/auth/signup', description: 'Register a new user' },
+      { method: 'POST', path: '/api/auth/login', description: 'Log in and start a session' },
+      { method: 'POST', path: '/api/auth/logout', description: 'End the session' },
+      { method: 'GET', path: '/api/auth/me', description: 'Get the current user' },
+    ],
+    note:
+      'User-scoped tables include a user_id column; filter rows by the authenticated user.',
+  }
+}
+
+/** Generate a small, dependency-free TS client the generated UI can drop in. */
+export function buildClientSdk(schema: InferredSchema): string {
+  const tableNames = schema.tables.map((t) => t.name)
+  const union = tableNames.map((t) => `'${t}'`).join(' | ') || 'string'
+  return [
+    '// Auto-generated ZeroDB client for this app (Issue #36).',
+    '// No API key is exposed — all calls proxy through /api/db.',
+    `export type TableName = ${union}`,
+    '',
+    'export const db = {',
+    '  async list(table: TableName, limit = 50) {',
+    '    const res = await fetch(`/api/db/${table}?limit=${limit}`)',
+    '    if (!res.ok) throw new Error(`list ${table} failed: ${res.status}`)',
+    '    return res.json()',
+    '  },',
+    '  async query(table: TableName, filters: Record<string, unknown>, limit = 50) {',
+    '    const qs = new URLSearchParams({ filter: JSON.stringify(filters), limit: String(limit) })',
+    '    const res = await fetch(`/api/db/${table}?${qs}`)',
+    '    if (!res.ok) throw new Error(`query ${table} failed: ${res.status}`)',
+    '    return res.json()',
+    '  },',
+    '  async create(table: TableName, row: Record<string, unknown>) {',
+    '    const res = await fetch(`/api/db/${table}`, {',
+    "      method: 'POST',",
+    "      headers: { 'Content-Type': 'application/json' },",
+    '      body: JSON.stringify(row),',
+    '    })',
+    '    if (!res.ok) throw new Error(`create ${table} failed: ${res.status}`)',
+    '    return res.json()',
+    '  },',
+    '  async update(table: TableName, id: string, row: Record<string, unknown>) {',
+    '    const res = await fetch(`/api/db/${table}?id=${id}`, {',
+    "      method: 'PUT',",
+    "      headers: { 'Content-Type': 'application/json' },",
+    '      body: JSON.stringify(row),',
+    '    })',
+    '    if (!res.ok) throw new Error(`update ${table} failed: ${res.status}`)',
+    '    return res.json()',
+    '  },',
+    '  async remove(table: TableName, id: string) {',
+    '    const res = await fetch(`/api/db/${table}?id=${id}`, { method: \'DELETE\' })',
+    '    if (!res.ok) throw new Error(`delete ${table} failed: ${res.status}`)',
+    '    return res.json()',
+    '  },',
+    '}',
+    '',
+  ].join('\n')
+}
+
+/** Provision a single table in ZeroDB (idempotent, best-effort). */
+async function provisionTable(
+  projectId: string,
+  table: InferredTable
+): Promise<TableProvisionResult> {
+  if (!API_KEY) {
+    return {
+      table: table.name,
+      status: 'skipped',
+      detail: 'ZERODB_API_KEY not set',
+    }
+  }
+
+  try {
+    const res = await fetch(
+      `${ZERODB_API}/v1/projects/${projectId}/database/tables`,
+      {
+        method: 'POST',
+        headers: { 'X-API-Key': API_KEY, 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          table_name: table.name,
+          // ZeroDB is schema-flexible; we pass the inferred shape as a hint.
+          schema: {
+            columns: table.columns.map((c) => ({
+              name: c.name,
+              type: c.type,
+              required: c.required,
+              unique: c.unique ?? false,
+            })),
+          },
+        }),
+        signal: AbortSignal.timeout(10000),
+      }
+    )
+
+    if (res.ok) {
+      return { table: table.name, status: 'created' }
+    }
+    // Treat "already exists" style responses as a non-error.
+    if (res.status === 409) {
+      return { table: table.name, status: 'exists' }
+    }
+    const detail = await res.text().catch(() => '')
+    logger.warn('Table provisioning returned non-OK', {
+      table: table.name,
+      status: res.status,
+    })
+    return { table: table.name, status: 'failed', detail: `${res.status} ${detail}`.trim() }
+  } catch (error) {
+    logger.error('Table provisioning error', error as Error, { table: table.name })
+    return {
+      table: table.name,
+      status: 'failed',
+      detail: error instanceof Error ? error.message : 'unknown error',
+    }
+  }
+}
+
+/**
+ * Full-stack backend generation entry point.
+ * Infers the schema, provisions tables (unless dryRun), and returns everything
+ * the UI-generation step and the deploy step need.
+ */
+export async function generateBackend(
+  prompt: string,
+  options: GenerateBackendOptions = {}
+): Promise<FullStackResult> {
+  const projectId = options.projectId || DEFAULT_PROJECT_ID
+  const schema = inferSchema(prompt, options)
+
+  logger.info('Full-stack backend inferred', {
+    tables: schema.tables.map((t) => t.name),
+    requiresAuth: schema.requiresAuth,
+  })
+
+  let provisioned: TableProvisionResult[]
+  if (options.dryRun) {
+    provisioned = schema.tables.map((t) => ({
+      table: t.name,
+      status: 'skipped' as const,
+      detail: 'dry run',
+    }))
+  } else {
+    provisioned = await Promise.all(
+      schema.tables.map((t) => provisionTable(projectId, t))
+    )
+  }
+
+  const endpoints = schema.tables.flatMap((t) => endpointsForTable(t.name))
+  const auth = buildAuthScaffold(schema)
+  if (auth) endpoints.push(...auth.endpoints)
+
+  return {
+    schema,
+    summary: describeSchema(schema),
+    projectId,
+    provisioned,
+    endpoints,
+    clientSdk: buildClientSdk(schema),
+    auth,
+  }
+}

--- a/lib/services/schema-inference.service.ts
+++ b/lib/services/schema-inference.service.ts
@@ -1,0 +1,473 @@
+/**
+ * Schema Inference Service (Issue #36)
+ *
+ * Turns a natural-language app description into a concrete backend data model
+ * (tables + typed columns + relationships) so the builder can auto-provision a
+ * ZeroDB backend alongside the generated UI.
+ *
+ * This module is intentionally PURE (no network, no DB) so the inference logic
+ * is deterministic and unit-testable. Provisioning against ZeroDB lives in
+ * `fullstack-generator.service.ts`, which consumes the model produced here.
+ *
+ * Design goals:
+ * - Deterministic: same prompt -> same schema (no LLM randomness in this layer).
+ * - Safe: table/column names are always normalized to snake_case identifiers.
+ * - Sensible defaults: every table gets id/created_at/updated_at + auth linkage
+ *   when the app is user-scoped.
+ */
+
+/** Column data types supported by the inferred data model. */
+export type InferredColumnType =
+  | 'uuid'
+  | 'string'
+  | 'text'
+  | 'integer'
+  | 'number'
+  | 'boolean'
+  | 'datetime'
+  | 'email'
+  | 'url'
+  | 'json'
+
+/** A single inferred column. */
+export interface InferredColumn {
+  name: string
+  type: InferredColumnType
+  required: boolean
+  unique?: boolean
+  /** Set when this column references another table's primary key. */
+  references?: { table: string; column: string }
+  /** Human-friendly reason this column was inferred (useful for UI/debugging). */
+  note?: string
+}
+
+/** A single inferred table. */
+export interface InferredTable {
+  /** snake_case, pluralized identifier used as the ZeroDB table name. */
+  name: string
+  /** Singular, title-cased label for UI. */
+  displayName: string
+  columns: InferredColumn[]
+  /** True when rows are owned by a user (adds user_id + auth requirement). */
+  userScoped: boolean
+}
+
+/** The complete inferred backend model. */
+export interface InferredSchema {
+  tables: InferredTable[]
+  /** Whether the app needs authentication (login/signup). */
+  requiresAuth: boolean
+  /** Whether a vector/semantic-search table was requested. */
+  requiresVectorSearch: boolean
+  /** Free-form notes explaining inference decisions. */
+  notes: string[]
+}
+
+/** Options controlling inference behaviour. */
+export interface InferenceOptions {
+  /** Force auth on/off instead of inferring from the prompt. */
+  requireAuth?: boolean
+  /** Cap on number of tables to avoid runaway provisioning. Default 8. */
+  maxTables?: number
+}
+
+const DEFAULT_MAX_TABLES = 8
+
+/**
+ * Common "entity" nouns that strongly imply a data table when they appear in a
+ * builder prompt. Mapped to the columns that entity usually needs. This is a
+ * curated library rather than an exhaustive one — anything not listed still
+ * gets picked up by the generic noun extractor with a default column set.
+ */
+const ENTITY_LIBRARY: Record<string, { columns: InferredColumn[] }> = {
+  task: {
+    columns: [
+      { name: 'title', type: 'string', required: true },
+      { name: 'description', type: 'text', required: false },
+      { name: 'status', type: 'string', required: false, note: 'e.g. todo/doing/done' },
+      { name: 'due_date', type: 'datetime', required: false },
+      { name: 'completed', type: 'boolean', required: false },
+    ],
+  },
+  todo: {
+    columns: [
+      { name: 'title', type: 'string', required: true },
+      { name: 'completed', type: 'boolean', required: false },
+      { name: 'priority', type: 'integer', required: false },
+    ],
+  },
+  note: {
+    columns: [
+      { name: 'title', type: 'string', required: true },
+      { name: 'body', type: 'text', required: false },
+      { name: 'pinned', type: 'boolean', required: false },
+    ],
+  },
+  post: {
+    columns: [
+      { name: 'title', type: 'string', required: true },
+      { name: 'slug', type: 'string', required: false, unique: true },
+      { name: 'body', type: 'text', required: false },
+      { name: 'published', type: 'boolean', required: false },
+    ],
+  },
+  product: {
+    columns: [
+      { name: 'name', type: 'string', required: true },
+      { name: 'description', type: 'text', required: false },
+      { name: 'price', type: 'number', required: true },
+      { name: 'sku', type: 'string', required: false, unique: true },
+      { name: 'in_stock', type: 'boolean', required: false },
+    ],
+  },
+  order: {
+    columns: [
+      { name: 'total', type: 'number', required: true },
+      { name: 'status', type: 'string', required: false },
+      { name: 'placed_at', type: 'datetime', required: false },
+    ],
+  },
+  customer: {
+    columns: [
+      { name: 'name', type: 'string', required: true },
+      { name: 'email', type: 'email', required: true, unique: true },
+      { name: 'phone', type: 'string', required: false },
+    ],
+  },
+  contact: {
+    columns: [
+      { name: 'name', type: 'string', required: true },
+      { name: 'email', type: 'email', required: false },
+      { name: 'phone', type: 'string', required: false },
+    ],
+  },
+  user: {
+    columns: [
+      { name: 'email', type: 'email', required: true, unique: true },
+      { name: 'name', type: 'string', required: false },
+      { name: 'avatar_url', type: 'url', required: false },
+    ],
+  },
+  event: {
+    columns: [
+      { name: 'title', type: 'string', required: true },
+      { name: 'starts_at', type: 'datetime', required: true },
+      { name: 'ends_at', type: 'datetime', required: false },
+      { name: 'location', type: 'string', required: false },
+    ],
+  },
+  comment: {
+    columns: [
+      { name: 'body', type: 'text', required: true },
+    ],
+  },
+  message: {
+    columns: [
+      { name: 'body', type: 'text', required: true },
+      { name: 'sent_at', type: 'datetime', required: false },
+    ],
+  },
+  project: {
+    columns: [
+      { name: 'name', type: 'string', required: true },
+      { name: 'description', type: 'text', required: false },
+    ],
+  },
+  invoice: {
+    columns: [
+      { name: 'number', type: 'string', required: true, unique: true },
+      { name: 'amount', type: 'number', required: true },
+      { name: 'paid', type: 'boolean', required: false },
+      { name: 'due_date', type: 'datetime', required: false },
+    ],
+  },
+  booking: {
+    columns: [
+      { name: 'starts_at', type: 'datetime', required: true },
+      { name: 'ends_at', type: 'datetime', required: false },
+      { name: 'status', type: 'string', required: false },
+    ],
+  },
+}
+
+/** Irregular plurals we care about; everything else uses the +s/+es rule. */
+const IRREGULAR_PLURALS: Record<string, string> = {
+  person: 'people',
+  category: 'categories',
+  company: 'companies',
+  activity: 'activities',
+  inventory: 'inventories',
+}
+
+/** Words that look like nouns but are never data tables in this context. */
+const NOISE_WORDS = new Set([
+  'app',
+  'application',
+  'page',
+  'website',
+  'site',
+  'dashboard',
+  'ui',
+  'interface',
+  'button',
+  'form',
+  'list',
+  'view',
+  'data',
+  'database',
+  'backend',
+  'frontend',
+  'api',
+  'user',
+  'users',
+  'login',
+  'signup',
+  'auth',
+  'authentication',
+  'thing',
+  'things',
+  'item',
+  'items',
+  'system',
+  'feature',
+  'section',
+  'component',
+])
+
+/** Convert an arbitrary token to a snake_case identifier. */
+export function toSnakeCase(input: string): string {
+  return input
+    .trim()
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .replace(/[\s-]+/g, '_')
+    .replace(/[^a-zA-Z0-9_]/g, '')
+    .replace(/_+/g, '_')
+    .replace(/^_|_$/g, '')
+    .toLowerCase()
+}
+
+/** Naive-but-correct-enough singularizer for our entity library. */
+export function singularize(word: string): string {
+  const w = word.toLowerCase()
+  for (const [sing, plur] of Object.entries(IRREGULAR_PLURALS)) {
+    if (w === plur) return sing
+  }
+  if (w.endsWith('ies')) return w.slice(0, -3) + 'y'
+  if (w.endsWith('sses')) return w.slice(0, -2) // classes -> class
+  if (w.endsWith('ses')) return w.slice(0, -2) // statuses -> status
+  if (w.endsWith('es') && (w.endsWith('xes') || w.endsWith('ches') || w.endsWith('shes')))
+    return w.slice(0, -2)
+  if (w.endsWith('s') && !w.endsWith('ss')) return w.slice(0, -1)
+  return w
+}
+
+/** Pluralize a singular noun for use as a table name. */
+export function pluralize(word: string): string {
+  const w = word.toLowerCase()
+  if (IRREGULAR_PLURALS[w]) return IRREGULAR_PLURALS[w]
+  if (/[^aeiou]y$/.test(w)) return w.slice(0, -1) + 'ies'
+  if (/(s|x|z|ch|sh)$/.test(w)) return w + 'es'
+  return w + 's'
+}
+
+/** Title-case a singular noun for display. */
+function titleCase(word: string): string {
+  return word
+    .split('_')
+    .filter(Boolean)
+    .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
+    .join(' ')
+}
+
+/**
+ * Does the prompt indicate the app needs authentication?
+ * Looks for explicit auth language and for personalization cues ("my", "user's").
+ */
+export function detectAuthRequirement(prompt: string): boolean {
+  const p = prompt.toLowerCase()
+  const authSignals = [
+    'auth',
+    'login',
+    'log in',
+    'sign in',
+    'sign up',
+    'signup',
+    'register',
+    'account',
+    'password',
+    'user account',
+    'per user',
+    'per-user',
+    'my ',
+    "user's",
+    'multi-user',
+    'multi user',
+    'permission',
+    'role',
+  ]
+  return authSignals.some((s) => p.includes(s))
+}
+
+/** Does the prompt request semantic / vector search? */
+export function detectVectorRequirement(prompt: string): boolean {
+  const p = prompt.toLowerCase()
+  return [
+    'semantic search',
+    'vector search',
+    'similarity search',
+    'embedding',
+    'rag',
+    'ai search',
+  ].some((s) => p.includes(s))
+}
+
+/**
+ * Extract candidate entity singulars from a prompt.
+ * Strategy:
+ *  1. Prefer known entities from ENTITY_LIBRARY (matched as whole words,
+ *     singular or plural).
+ *  2. Fall back to plural nouns in the text that survive the noise filter.
+ * Returns an ordered, de-duplicated list of singular entity names.
+ */
+export function extractEntities(prompt: string): string[] {
+  const p = prompt.toLowerCase()
+  const found: string[] = []
+  const seen = new Set<string>()
+
+  const add = (singular: string) => {
+    const key = toSnakeCase(singular)
+    if (!key || key.length < 3) return
+    if (NOISE_WORDS.has(key) || NOISE_WORDS.has(pluralize(key))) return
+    if (seen.has(key)) return
+    seen.add(key)
+    found.push(key)
+  }
+
+  // 1. Known entities (match singular or plural as whole words).
+  for (const entity of Object.keys(ENTITY_LIBRARY)) {
+    const plural = pluralize(entity)
+    const re = new RegExp(`\\b(${entity}|${plural})\\b`, 'i')
+    if (re.test(p)) add(entity)
+  }
+
+  // 2. Generic plural-noun extraction for anything not in the library.
+  const tokens = p.match(/[a-z][a-z0-9]{2,}/gi) || []
+  for (const raw of tokens) {
+    const token = raw.toLowerCase()
+    // Only consider plausible plurals to avoid grabbing every verb/adjective.
+    const looksPlural =
+      token.endsWith('s') && !token.endsWith('ss') && !token.endsWith('us')
+    if (!looksPlural) continue
+    const singular = singularize(token)
+    if (NOISE_WORDS.has(token) || NOISE_WORDS.has(singular)) continue
+    add(singular)
+  }
+
+  return found
+}
+
+/** Build the standard system columns present on every table. */
+function systemColumns(userScoped: boolean): InferredColumn[] {
+  const cols: InferredColumn[] = [
+    { name: 'id', type: 'uuid', required: true, unique: true, note: 'primary key' },
+  ]
+  if (userScoped) {
+    cols.push({
+      name: 'user_id',
+      type: 'uuid',
+      required: true,
+      references: { table: 'users', column: 'id' },
+      note: 'owner (auth-scoped)',
+    })
+  }
+  cols.push(
+    { name: 'created_at', type: 'datetime', required: true, note: 'auto timestamp' },
+    { name: 'updated_at', type: 'datetime', required: true, note: 'auto timestamp' }
+  )
+  return cols
+}
+
+/** Build a single table from a singular entity name. */
+function buildTable(entity: string, userScoped: boolean): InferredTable {
+  const known = ENTITY_LIBRARY[entity]
+  const domainColumns: InferredColumn[] = known
+    ? known.columns.map((c) => ({ ...c }))
+    : [
+        { name: 'name', type: 'string', required: true },
+        { name: 'description', type: 'text', required: false },
+      ]
+
+  const name = pluralize(entity)
+  // Never double-scope the users table itself.
+  const scoped = userScoped && name !== 'users'
+
+  return {
+    name,
+    displayName: titleCase(entity),
+    userScoped: scoped,
+    columns: [...systemColumns(scoped), ...domainColumns],
+  }
+}
+
+/**
+ * Infer a complete backend data model from a natural-language prompt.
+ * Pure and deterministic.
+ */
+export function inferSchema(
+  prompt: string,
+  options: InferenceOptions = {}
+): InferredSchema {
+  const maxTables = options.maxTables ?? DEFAULT_MAX_TABLES
+  const notes: string[] = []
+
+  const requiresAuth =
+    options.requireAuth !== undefined
+      ? options.requireAuth
+      : detectAuthRequirement(prompt)
+  const requiresVectorSearch = detectVectorRequirement(prompt)
+
+  let entities = extractEntities(prompt)
+
+  if (entities.length === 0) {
+    // Nothing recognizable — fall back to a single generic "items" table so the
+    // generated app still has a working backend to talk to.
+    entities = ['item']
+    notes.push('No specific entities detected; provisioned a generic "items" table.')
+  }
+
+  // Cap and de-dupe (extractEntities already de-dupes, but respect maxTables).
+  if (entities.length > maxTables) {
+    notes.push(
+      `Detected ${entities.length} entities; capped to ${maxTables} tables.`
+    )
+    entities = entities.slice(0, maxTables)
+  }
+
+  const tables = entities.map((e) => buildTable(e, requiresAuth))
+
+  // When auth is required, ensure a users table exists even if not named.
+  if (requiresAuth && !tables.some((t) => t.name === 'users')) {
+    tables.unshift(buildTable('user', false))
+    notes.push('Auth requested: added a "users" table.')
+  }
+
+  if (requiresVectorSearch) {
+    notes.push('Semantic search requested: a vector index should be provisioned.')
+  }
+
+  return { tables, requiresAuth, requiresVectorSearch, notes }
+}
+
+/** Render the inferred schema as a human-readable summary (for UI/logs). */
+export function describeSchema(schema: InferredSchema): string {
+  const lines: string[] = []
+  lines.push(
+    `${schema.tables.length} table(s)` +
+      (schema.requiresAuth ? ', with authentication' : '') +
+      (schema.requiresVectorSearch ? ', with vector search' : '')
+  )
+  for (const t of schema.tables) {
+    lines.push(`- ${t.name} (${t.columns.length} columns)`)
+  }
+  return lines.join('\n')
+}


### PR DESCRIPTION
## Summary

Closes #36. Upgrades the builder from **UI-only** generation to **full-stack** generation: given a natural-language app description, it now infers a backend data model and auto-provisions a ZeroDB backend (tables, auth scoping, vector-search awareness) alongside the UI.

This composes with what already existed in the repo (CRUD intent detection, schema-prompt enhancement, the `/api/db/{table}` proxy, and `/api/deploy`) — the missing piece was turning a prompt into a **provisionable** data model. That is what this PR adds.

### What's new

- **`lib/services/schema-inference.service.ts`** — pure, deterministic `prompt -> data model`:
  - Extracts entities (curated library + generic plural-noun fallback), builds typed columns.
  - Adds system columns (`id`, `created_at`, `updated_at`) to every table.
  - Detects auth need and adds a `users` table + `user_id` FK scoping on owned tables.
  - Detects semantic/vector-search intent.
  - Helpers: `toSnakeCase`, `singularize`, `pluralize`, `describeSchema`.
- **`lib/services/fullstack-generator.service.ts`** — orchestrator:
  - Infers schema, then **provisions ZeroDB tables** via the REST API (idempotent, best-effort; a failed create never blocks generation).
  - Emits CRUD `ApiEndpoint` descriptors, an **auth scaffold**, and a **drop-in typed TypeScript client** that proxies through `/api/db` (no API key leaked to the generated app).
  - Supports `dryRun` for preview/tests and a `projectId` override.
- **`app/api/fullstack/provision/route.ts`** — `POST` provisions (zod-validated), `GET ?prompt=` previews as a dry run.

### Test evidence

New suites (`pnpm exec vitest run` on the two new files):

```
✓ __tests__/services/schema-inference.service.test.ts (27 tests)
✓ __tests__/services/fullstack-generator.service.test.ts (10 tests)
Test Files  2 passed (2)
     Tests  37 passed (37)
```

Full suite (`pnpm test`): **620 passed, 30 skipped, 1 failed**. The single failure is pre-existing and unrelated (`agent-skill.service.test.ts` timing assertion `searchTime > 0`); a second suite is env-gated on `ANTHROPIC_API_KEY`. Both were verified failing on `origin/main` before this change.

### Build evidence

`pnpm build` (next build --turbopack):

```
✓ Compiled successfully
ƒ /api/fullstack/provision   ← new route registered
```

(The ESLint "must be installed" line is a pre-existing environment condition — `eslint` is not in devDependencies — and does not fail compilation or type-checking.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)