### PR TITLE
fix(gen): stop double-burning tokens on quota-402 (fail fast, no fallback)

### DIFF
--- a/__tests__/lib/quota-error.test.ts
+++ b/__tests__/lib/quota-error.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { isQuotaError, QUOTA_USER_MESSAGE } from '@/lib/quota-error'
+
+describe('isQuotaError', () => {
+  it('detects the live 402 monthly_token_limit_exceeded agent error string', () => {
+    const real =
+      '[ERR_API] AINative API error: 402 {"type":"error","error":{"type":"billing_error","message":"{\'error\': {\'code\': \'monthly_token_limit_exceeded\', \'message\': \\"You\'ve used your monthly token allotment (50,038,041 of 50,000,000 on the \'enterprise\' plan). Upgrade your plan or add credits to continue.\\", \'tier\': \'enterprise\', \'limit\': 50000000}}"}}'
+    expect(isQuotaError(real)).toBe(true)
+  })
+
+  it('detects a structured error object with status 402', () => {
+    expect(isQuotaError({ status: 402, message: 'Payment Required' })).toBe(true)
+    expect(isQuotaError({ statusCode: 402 })).toBe(true)
+    expect(isQuotaError({ code: 402 })).toBe(true)
+  })
+
+  it('detects billing_error and add-credits markers regardless of status', () => {
+    expect(isQuotaError('upstream returned billing_error')).toBe(true)
+    expect(isQuotaError('Upgrade your plan or add credits to continue')).toBe(true)
+    expect(isQuotaError('token allotment exhausted')).toBe(true)
+  })
+
+  it('does NOT match ordinary agent failures (should fall through to fallback)', () => {
+    expect(isQuotaError('Agent crashed: timeout after 120s')).toBe(false)
+    expect(isQuotaError('validation failed: missing default export')).toBe(false)
+    expect(isQuotaError({ status: 500, message: 'internal error' })).toBe(false)
+    expect(isQuotaError('rate limited 429')).toBe(false)
+  })
+
+  it('does not match a bare 402 without a billing marker (avoids false positives on random numbers)', () => {
+    expect(isQuotaError('processed 402 records successfully')).toBe(false)
+  })
+
+  it('handles null/undefined/empty safely', () => {
+    expect(isQuotaError(null)).toBe(false)
+    expect(isQuotaError(undefined)).toBe(false)
+    expect(isQuotaError('')).toBe(false)
+  })
+
+  it('exposes a user-facing message', () => {
+    expect(QUOTA_USER_MESSAGE).toMatch(/monthly token limit/i)
+  })
+})

--- a/app/api/chat-ws/route.ts
+++ b/app/api/chat-ws/route.ts
@@ -30,6 +30,7 @@ import { logModelConfiguration } from '@/lib/config/model-validator'
 import { isClaudeAgentEnabled, isClaudeAgentFallbackEnabled, runHeadlessAgent } from '@/lib/agent/claude-agent'
 import { cleanupWorktree } from '@/lib/agent/worktree-manager'
 import { logAgentRun } from '@/lib/services/agent-runs.service'
+import { isQuotaError, QUOTA_USER_MESSAGE } from '@/lib/quota-error'
 
 // Log model configuration on first module load
 logModelConfiguration()
@@ -173,6 +174,12 @@ export async function POST(request: NextRequest) {
 
         try {
           let fullContent = ''
+          // Set when the primary agent failed specifically because the account is
+          // out of monthly tokens (HTTP 402). The standard fallback would bill the
+          // SAME exhausted account and just burn more tokens, so when this is set we
+          // skip the fallback and fail fast with an actionable message. Declared in
+          // the outer generation scope so the quota short-circuit below can read it.
+          let agentQuotaExhausted = false
           let lastUpdateTime = Date.now()
           const generationStartTime = Date.now()
           let tokenUsage: any = undefined
@@ -385,12 +392,24 @@ export async function POST(request: NextRequest) {
                     agentError = event.error
                     if (event.fatal) {
                       agentFailed = true
-                      // Send error to client but do NOT close — we will fall through
-                      // to the existing model call path below
-                      safeEnqueue(encoder.encode(`data: ${JSON.stringify({
-                        type: 'build_step',
-                        step: 'Agent failed — falling back to standard generation',
-                      })}\n\n`))
+                      // If the fatal error is a quota/billing exhaustion, the
+                      // standard fallback path bills the same empty account and
+                      // will just fail again — so don't offer it, and flag it so
+                      // we short-circuit below instead of double-burning tokens.
+                      if (isQuotaError(event.error)) {
+                        agentQuotaExhausted = true
+                        safeEnqueue(encoder.encode(`data: ${JSON.stringify({
+                          type: 'build_step',
+                          step: QUOTA_USER_MESSAGE,
+                        })}\n\n`))
+                      } else {
+                        // Send error to client but do NOT close — we will fall through
+                        // to the existing model call path below
+                        safeEnqueue(encoder.encode(`data: ${JSON.stringify({
+                          type: 'build_step',
+                          step: 'Agent failed — falling back to standard generation',
+                        })}\n\n`))
+                      }
                     } else {
                       // Non-fatal error — stream it as a build step so user sees it
                       safeEnqueue(encoder.encode(`data: ${JSON.stringify({
@@ -464,6 +483,35 @@ export async function POST(request: NextRequest) {
                 fullContent = '' // Reset so the fallback path starts clean
               }
             }
+          }
+
+          // Quota short-circuit: if the primary agent failed because the account
+          // is out of monthly tokens, the standard fallback path would bill the
+          // SAME exhausted account — burning more tokens on a request that cannot
+          // succeed (a doom loop that accelerates burn exactly when the account is
+          // empty). Emit a clear terminal error and stop instead of falling through.
+          if (agentQuotaExhausted && fullContent.length <= 100) {
+            console.warn('⛔ Quota exhausted (402) — skipping fallback to avoid double-billing an empty account')
+            import('@/lib/services/rlhf.service').then(({ logGenerationFailure }) => {
+              logGenerationFailure({
+                chatId: responseId,
+                userId,
+                prompt: message,
+                model: requestedModel || DEFAULT_MODEL,
+                error: 'monthly_token_limit_exceeded',
+                systemPrompt: '',
+                generationTimeMs: Date.now() - generationStartTime,
+              }).catch(() => {})
+            }).catch(() => {})
+            safeEnqueue(encoder.encode(`data: ${JSON.stringify({
+              type: 'error',
+              error: QUOTA_USER_MESSAGE,
+              code: 'quota_exhausted',
+            })}\n\n`))
+            keepaliveActive = false
+            clearInterval(keepaliveInterval)
+            try { controller.close() } catch (_) { /* already closed */ }
+            return
           }
 
           // Only run the standard model call path if the agent path was not used

--- a/lib/quota-error.ts
+++ b/lib/quota-error.ts
@@ -1,0 +1,58 @@
+/**
+ * Quota / billing error detection for generation paths.
+ *
+ * When the AINative account is out of monthly tokens, the upstream API returns
+ * HTTP 402 with a `billing_error` / `monthly_token_limit_exceeded` payload.
+ *
+ * This matters because the generation route has a PRIMARY agent path (Cody) and
+ * a FALLBACK standard-generation path. On a normal agent failure, falling
+ * through to the fallback is correct. But on a QUOTA failure, the fallback bills
+ * the SAME exhausted account — so it just burns more tokens and fails again
+ * (a "doom loop" that accelerates burn precisely when the account is empty).
+ *
+ * Detecting the quota case lets callers fail fast with an actionable message
+ * instead of doubling token spend on a request that cannot succeed.
+ */
+
+const QUOTA_MARKERS = [
+  'monthly_token_limit_exceeded',
+  'billing_error',
+  'token allotment',
+  'add credits to continue',
+]
+
+/**
+ * Returns true if the given error text/object represents an upstream quota or
+ * billing exhaustion (HTTP 402 monthly_token_limit_exceeded and friends).
+ * Deliberately liberal on the text match, strict on the 402 status.
+ */
+export function isQuotaError(err: unknown): boolean {
+  if (err == null) return false
+
+  // Structured error with a status/code
+  const anyErr = err as { status?: number; code?: number; statusCode?: number }
+  const status = anyErr.status ?? anyErr.code ?? anyErr.statusCode
+  if (status === 402) return true
+
+  const text =
+    typeof err === 'string'
+      ? err
+      : (() => {
+          try {
+            return JSON.stringify(err)
+          } catch {
+            return String((err as { message?: string })?.message ?? err)
+          }
+        })()
+
+  const lower = text.toLowerCase()
+  // A bare "402" in the text is only conclusive alongside a billing marker,
+  // to avoid matching unrelated numbers.
+  const has402 = /\b402\b/.test(lower)
+  const hasMarker = QUOTA_MARKERS.some((m) => lower.includes(m))
+  return hasMarker || (has402 && lower.includes('billing'))
+}
+
+/** User-facing message when generation cannot proceed due to account quota. */
+export const QUOTA_USER_MESSAGE =
+  'Generation is temporarily unavailable — the workspace has reached its monthly token limit. Please try again shortly while we top up capacity.'

--- a/scripts/ainative-usage-breakdown.mjs
+++ b/scripts/ainative-usage-breakdown.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/**
+ * Pull the AINative token-usage breakdown for the account behind the builder.
+ *
+ * WHY: 50M/50M monthly tokens were consumed unexpectedly fast. This queries the
+ * managed usage endpoint to show WHERE the tokens went (by model / endpoint /
+ * day) so we can tell organic traffic from a runaway loop.
+ *
+ * REQUIRES an ADMIN-SCOPED token — NOT an sk_ Instant-DB/agent key.
+ * Pass it via AINATIVE_ADMIN_TOKEN (never commit it, never print it).
+ *
+ *   AINATIVE_ADMIN_TOKEN=<admin-token> node scripts/ainative-usage-breakdown.mjs
+ *
+ * Optional: AINATIVE_API_URL to override base (default https://api.ainative.studio).
+ */
+
+const BASE = (process.env.AINATIVE_API_URL || 'https://api.ainative.studio') + '/v1'
+const TOKEN = process.env.AINATIVE_ADMIN_TOKEN
+
+if (!TOKEN) {
+  console.error('❌ AINATIVE_ADMIN_TOKEN is not set. Provide an admin-scoped token (not an sk_ key).')
+  process.exit(1)
+}
+if (TOKEN.startsWith('sk_')) {
+  console.error('❌ That looks like an sk_ Instant-DB/agent key. Use a proper admin-scoped token instead.')
+  process.exit(1)
+}
+
+const headers = { Authorization: `Bearer ${TOKEN}`, 'Content-Type': 'application/json' }
+
+async function get(path) {
+  const res = await fetch(`${BASE}${path}`, { headers })
+  const text = await res.text()
+  let body
+  try { body = JSON.parse(text) } catch { body = text }
+  return { status: res.status, body }
+}
+
+const ENDPOINTS = [
+  '/managed/usage?period=month',
+  '/managed/usage?period=month&group_by=model',
+  '/managed/usage?period=month&group_by=day',
+  '/managed/usage?period=month&group_by=api_key',
+  '/public/billing',
+  '/subscription',
+]
+
+console.log(`\nAINative usage breakdown — ${BASE}\n${'='.repeat(60)}`)
+for (const ep of ENDPOINTS) {
+  const { status, body } = await get(ep)
+  console.log(`\n### GET ${ep}  →  HTTP ${status}`)
+  console.log(typeof body === 'string' ? body.slice(0, 2000) : JSON.stringify(body, null, 2).slice(0, 4000))
+}
+console.log(`\n${'='.repeat(60)}\nLook for: which model/api_key/day dominates the 50M. A single key or a`)
+console.log(`single day spiking = runaway loop or leaked key, not organic user traffic.\n`)


### PR DESCRIPTION
## Problem
The builder's AINative account hit **50,038,041 / 50,000,000** monthly tokens (`enterprise` plan) in ~a day. Root-cause investigation of the generation path found a **token amplifier**:

When the primary Cody agent fails with an **HTTP 402 `monthly_token_limit_exceeded`**, `/api/chat-ws` treated it like any failure and **fell through to a full standard (Sonnet) re-generation** — billing the *same exhausted account* again. So every request paid for a failed primary **plus** a futile fallback. The more exhausted the account, the faster it burned (a doom loop).

Verified live: a real prompt to prod streamed the 402, then `Agent failed — falling back to standard generation` → second full generation.

## Fix
- **`lib/quota-error.ts`** — `isQuotaError()` detects `402` / `billing_error` / `monthly_token_limit_exceeded`; `QUOTA_USER_MESSAGE` for the client.
- **`app/api/chat-ws/route.ts`** — on a quota-402 fatal agent error, set `agentQuotaExhausted` and **short-circuit before the fallback**: stream a clear terminal `error` (`code: quota_exhausted`) and close cleanly. No second generation on an empty account.
- **`scripts/ainative-usage-breakdown.mjs`** — queries `/managed/usage` by model/day/api_key to identify what consumed the 50M (**admin token required; refuses `sk_` keys**).

## Evidence
- `next build` ✅ passes (110 static pages, chat-ws route compiled)
- `vitest` ✅ 7/7 quota-error tests pass (real 402 string, structured status, markers, negatives, null-safety)

## Not addressed here (needs ops)
- Raising / topping up the monthly token quota is a **billing action on the AINative core account**, not a builder code change.
- Confirming prod bills the correct key (not an `sk_` agent key) — key order is `AINATIVE_API_KEY || API_Key || ZERODB_API_KEY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)